### PR TITLE
Hiccups I found using powderday as a library

### DIFF
--- a/powderday/octree_zoom.py
+++ b/powderday/octree_zoom.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import numpy as np
-from yt.mods import load
 import powderday.config as cfg
+import yt
 from yt.frontends.sph.data_structures import ParticleDataset
 
 
@@ -58,9 +58,9 @@ def octree_zoom_bbox_filter(fname,pf,bbox0,field_add):
     
 
     try: #particle
-        ds1 = load(fname,bounding_box=bbox1,n_ref = cfg.par.n_ref,over_refine_factor=cfg.par.oref)
+        ds1 = yt.load(fname,bounding_box=bbox1,n_ref = cfg.par.n_ref,over_refine_factor=cfg.par.oref)
     except: #amr
-        ds1 = load(fname,n_ref = cfg.par.n_ref,over_refine_factor=cfg.par.oref)
+        ds1 = yt.load(fname,n_ref = cfg.par.n_ref,over_refine_factor=cfg.par.oref)
         bbox1 = None
 
     ds1.periodicity = (False,False,False)

--- a/powderday/sph_tributary.py
+++ b/powderday/sph_tributary.py
@@ -102,7 +102,7 @@ def sph_m_gen(fname,field_add):
         frac = cfg.par.PAH_frac
 
         # Normalize to 1
-        total = np.sum(frac.values())
+        total = np.sum(list(frac.values()))
         frac = {k: v / total for k, v in frac.items()}
 
         for size in frac.keys():


### PR DESCRIPTION
To load files, we should use `yt.load` not `yt.mods.load`. `yt.mods.load` is the `yt load` CLI hook, and having `yt.mods.load` imported by `powderday` in one of my CLI scripts steamrolls my command-line arguments.
