### PR TITLE
Stop AGN variability code from repeatedly recalculating variable fraction

### DIFF
--- a/powderday/agn_models/hickox.py
+++ b/powderday/agn_models/hickox.py
@@ -11,9 +11,9 @@ def Hickox2014(L_cut=100, alpha=0.2):
     return t0 * p0, L
 
 def vary_bhluminosity(size):
-'''
-    Returns a list of fractions by which to vary the luminosity.
-'''
+    '''
+        Returns a list of fractions by which to vary the luminosity.
+    '''
     PDF, L_frac = Hickox2014()
     CDF = np.cumsum(PDF) / sum(PDF)
     choice = np.random.random(size)

--- a/powderday/agn_models/hickox.py
+++ b/powderday/agn_models/hickox.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import numpy as np
 '''
-    Vary the instantaneous BH luminosity by sampling the probability distribution from Hickox et al (2014) for short and long-scale time variations.
+    Vary the instantaneous BH luminosity by sampling the probability distribution from Hickox et al (2014) for short time-scale variations.
     - Ray Sharma
 '''
 def Hickox2014(L_cut=100, alpha=0.2):
@@ -10,9 +10,12 @@ def Hickox2014(L_cut=100, alpha=0.2):
     t0 = 0.00854
     return t0 * p0, L
 
-def vary_bhluminosity(L_avg):
+def vary_bhluminosity(size):
+'''
+    Returns a list of fractions by which to vary the luminosity.
+'''
     PDF, L_frac = Hickox2014()
     CDF = np.cumsum(PDF) / sum(PDF)
-    choice = np.random.random(len(L_avg))
+    choice = np.random.random(size)
     ix = [np.argmin(abs(CDF - x)) for x in choice]
-    return L_avg * L_frac[ix]
+    return L_frac[ix]

--- a/powderday/front_ends/CSgadget2pd.py
+++ b/powderday/front_ends/CSgadget2pd.py
@@ -156,8 +156,7 @@ def gadget_field_add(fname,bounding_box = None,ds=None,starages=False):
         c = yt.utilities.physical_constants.speed_of_light_cgs
         bhluminosity = (cfg.par.BH_eta * mdot * c**2.).in_units("erg/s")
         if cfg.par.BH_var:
-            global bhlfrac
-            return bhluminosity * bhlfrac
+            return bhluminosity * cfg.par.bhlfrac
         else:
             return bhluminosity
         
@@ -281,7 +280,7 @@ def gadget_field_add(fname,bounding_box = None,ds=None,starages=False):
 
                 if cfg.par.BH_var:
                     from powderday.agn_models.hickox import vary_bhluminosity
-                    bhlfrac = vary_bhluminosity(nholes)
+                    cfg.par.bhlfrac = vary_bhluminosity(nholes)
 
                 ds.add_field(("bhluminosity"),function=_bhluminosity,units='erg/s',particle_type=True)
                 ds.add_field(("bhcoordinates"),function=_bhcoordinates,units="cm",particle_type=True)

--- a/powderday/front_ends/gadget2pd.py
+++ b/powderday/front_ends/gadget2pd.py
@@ -141,8 +141,7 @@ def gadget_field_add(fname, bounding_box=None, ds=None, starages=False):
         c = yt.utilities.physical_constants.speed_of_light_cgs
         bhluminosity = (cfg.par.BH_eta * mdot * c**2.).in_units("erg/s")
         if cfg.par.BH_var:
-            global bhlfrac
-            return bhluminosity * bhlfrac
+            return bhluminosity * cfg.par.bhlfrac
         else:
             return bhluminosity
 
@@ -263,7 +262,7 @@ def gadget_field_add(fname, bounding_box=None, ds=None, starages=False):
 
                 if cfg.par.BH_var:
                     from powderday.agn_models.hickox import vary_bhluminosity
-                    bhlfrac = vary_bhluminosity(nholes)
+                    cfg.par.bhlfrac = vary_bhluminosity(nholes)
 
                 ds.add_field(("bhluminosity"),function=_bhluminosity,units='erg/s',particle_type=True)
                 ds.add_field(("bhcoordinates"),function=_bhcoordinates,units="cm",particle_type=True)

--- a/powderday/source_creation.py
+++ b/powderday/source_creation.py
@@ -471,7 +471,7 @@ def BH_source_add(m,pf,df_nu,boost):
 
         dump_AGN_SEDs(nu,master_bh_fnu,ad["bhluminosity"].value)
     except:
-        pass
+        print('BH source creation failed.')
     #savefile = cfg.model.PD_output_dir+"/bh_sed.npz"
     #np.savez(savefile,nu = nu,fnu = master_bh_fnu,luminosity = ad["bhluminosity"].value)
     


### PR DESCRIPTION
After adding a new field to a YT data array, any calls to the field , e.g,
`ds.all_data()['bhluminosity']`
recalculates the property each time. This is somewhat puzzling behavior on the part of YT that I have not noticed before, but I sidestepped the issue by calculating the AGN variability fraction once and dumping it into
`cfg.par.bhlfrac = vary_bhluminosity(nholes)`
Hence any subsequent calls to the luminosity field will use the same variability fraction.

Checking the `bh_sed.npz` output indicates its producing a correctly varied AGN spectrum.

I didn't add `cfg.par.bhlfrac` to `backwards_compatibility.py` or `parameters_master.py` since it is only defined and used here. Maybe there's a better way of doing this?