### PR TITLE
Changing scaling of Nenkova output SED to match Hopkins SED.

### DIFF
--- a/powderday/agn_models/nenkova.py
+++ b/powderday/agn_models/nenkova.py
@@ -2,72 +2,54 @@ from __future__ import print_function
 import numpy as np
 import h5py
 import powderday.config as cfg
+from powderday.agn_models.hopkins import agn_spectrum as underlying_agn_spectrum
 
 '''
-    agn_spectrum using Nenkova+ (2008) torus models. Model calculations from CLUMPY (https://www.clumpy.org). Total spectrum is calculated as (Torus Flux) + (probability of AGN photon escape)x(AGN Flux). AGN spectra are assumed to be piecewise power-law (Rowan-Robinson 1995) with spectral breaks from Nenkova et al. Default CLUMPY model parameters taken from Nenkova et al.
+    agn_spectrum using Nenkova+ (2008) torus models. Model calculations from CLUMPY (https://www.clumpy.org). 
+    Total spectrum is calculated as (torus flux ratio) x (underlying AGN spectra). 
+    Underlying AGN spectra are assumed to be Hopkins+ (2007) templates. Default CLUMPY model parameters taken from Nenkova et al.
 
-    CLUMPY returns spectra in lambda * Flambda (arbitrary units). We scale such that the integrated Flambda gives the total IR luminosity.
+    CLUMPY returns spectra in lambda * Flambda (arbitrary units).
 
     - Ray Sharma
 '''
 
 
 class Nenkova2008:
-    def __init__(self, params=[5, 30, 0, 1.5, 30, 40]):
-        N0, Y, i, q, sig, tv = params
+    def __init__(self, N0=5, Y=30, i=0, q=1.5, sig=30, tv=40):
         self.N0 = N0
         self.Y = Y
         self.i = i
         self.q = q
         self.sig = sig
         self.tv = tv
+        try:
+            self.h = h5py.File(cfg.par.BH_modelfile, 'r')
+        except IOError:
+            raise IOError('Unable to find Nenkova BH model file. '
+                          'Check the path in parameters master, or '
+                          'download the file here: https://www.clump'
+                          'y.org/downloads/clumpy_models_201410_tvav'
+                          'g.hdf5')
+        self.check_params()
 
     def agn_spectrum(self, log_L_bol):
-        try:
-            h = h5py.File(cfg.par.BH_modelfile, 'r')
-        except:
-            raise IOError('Unable to find Nenkova BH model file. '
-                                    'Check the path in parameters master, or '
-                                    'download the file here: https://www.clump'
-                                    'y.org/downloads/clumpy_models_201410_tvav'
-                                    'g.hdf5')
-
-        ix = ((h['N0'][:] == self.N0) &
-              (h['Y'][:] == self.Y) &
-              (h['i'][:] == self.i) &
-              (h['q'][:] == self.q) &
-              (h['sig'][:] == self.sig) &
-              (h['tv'][:] == self.tv))
-
-        nu_vec = 3e14 / h['wave'][:]
-
-        frac_AGN_obsc = h['ptype1'][:][ix][0]
-        l_band_vec_torus = h['flux_tor'][:][ix][0]
-        l_band_vec_AGN = h['flux_toragn'][:][ix][0] - l_band_vec_torus
-        l_band_vec = l_band_vec_torus + (frac_AGN_obsc * l_band_vec_AGN)
-
-        l_band_vec = self.scale_spectrum(l_band_vec, nu_vec, log_L_bol)
-
-        l_band_vec = np.log10(l_band_vec)
-        l_band_vec = np.concatenate((l_band_vec, [0, 0, 0, 0]))
+        nu_vec = 3e14 / self.h['wave'][:]
         nu_vec = np.log10(nu_vec)
         nu_vec = np.concatenate((nu_vec, [-1, -2, -3, -4]))
 
-        to_cgs = np.log10(3.9) + 33
-        return nu_vec, l_band_vec + to_cgs
+        l_band_vec_torus = self.h['flux_tor'][:][self.ix][0]
 
-    def scale_spectrum(self, l_band_vec, nu_vec, log_L_bol):
-        ''' Scale the spectrum by (total IR luminosity) / (integrated spectrum in arb. units)
-        '''
-        L_IR = 10**self.bol_correct_IR(log_L_bol)
-        integrated_spec = np.trapz(l_band_vec / nu_vec, nu_vec)
-        norm = L_IR / abs(integrated_spec)
-        return l_band_vec * norm
+        agn_nu, agn_l_band_vec = underlying_agn_spectrum(log_L_bol)
+        l_band_vec = np.log10(l_band_vec_torus) + np.interp(
+            nu_vec[:-4], agn_nu[:-4], agn_l_band_vec[:-4])
+        l_band_vec = np.concatenate((l_band_vec, [0, 0, 0, 0]))
 
-    def bol_correct_IR(self, log_L_bol, c1=17.87, k1=0.28, c2=10.03, k2=0.020):
-        ''' Return log IR luminosity using bolometric corrections from Hopkins+ (2006). Defaults to 15micron band corrections.
-        '''
-        L_bol = 10**log_L_bol
-        L_IR = L_bol / (c1 * pow(L_bol / 1e10, k1) +
-                        c2 * pow(L_bol / 1e10, k2))
-        return np.log10(L_IR)
+        return nu_vec, l_band_vec
+
+    def check_params(self):
+        self.ix = ((self.h['N0'][:] == self.N0) & (self.h['Y'][:] == self.Y) &
+                   (self.h['i'][:] == self.i) & (self.h['q'][:] == self.q) &
+                   (self.h['sig'][:] == self.sig) & (self.h['tv'][:] == self.tv))
+        if self.ix.sum() == 0:
+            raise IOError('Input Nenkova model parameters cannot be found in model file.')

--- a/powderday/front_ends/CSgadget2pd.py
+++ b/powderday/front_ends/CSgadget2pd.py
@@ -265,11 +265,7 @@ def gadget_field_add(fname,bounding_box = None,ds=None,starages=False):
             if nholes > 0:
                 if cfg.par.BH_model == 'Nenkova':
                     from powderday.agn_models.nenkova import Nenkova2008
-                    try:
-                        model = Nenkova2008(cfg.par.nenkova_params)
-                    except:
-                        model = Nenkova2008
-                    agn_spectrum = model.agn_spectrum
+                    agn_spectrum = Nenkova2008(*cfg.par.nenkova_params).agn_spectrum
                 else:
                     from powderday.agn_models.hopkins import agn_spectrum
 

--- a/powderday/front_ends/gadget2pd.py
+++ b/powderday/front_ends/gadget2pd.py
@@ -246,11 +246,7 @@ def gadget_field_add(fname, bounding_box=None, ds=None, starages=False):
             if nholes > 0:
                 if cfg.par.BH_model == 'Nenkova':
                     from powderday.agn_models.nenkova import Nenkova2008
-                    try:
-                        model = Nenkova2008(cfg.par.nenkova_params)
-                    except:
-                        model = Nenkova2008
-                    agn_spectrum = model.agn_spectrum
+                    agn_spectrum = Nenkova2008(*cfg.par.nenkova_params).agn_spectrum
                 else:
                     from powderday.agn_models.hopkins import agn_spectrum
 


### PR DESCRIPTION
Changed Nenkova model to output an underlying AGN SED, convolved with the dust torus SED flux ratio. Current default for underlying SED is now Hopkins+ (2007) SED. Added better error handling for incorrect Nenkova params.
Output SED is mostly the same, though the underlying spectral shape is now Hopkins+ (2007) rather than the Nenkova default, Rowan-Robinson+ (1995).