### PR TITLE
Corrected the box length for the zoomed region in Enzo outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode
+dist
+build
+powderday.egg-info
+

--- a/pd_front_end.py
+++ b/pd_front_end.py
@@ -305,11 +305,11 @@ if cfg.par.IMAGING == True:
         m_imaging.run(model.outputfile+'.image', mpi=True, n_processes=par.n_MPI_processes, overwrite=True)
 
         convolve(model.outputfile+'.image', par.filterfiles, filter_data)
-
-    # Print a message in case that skip_rt debugging flag is set:
-    print('++++++++++++++++++++++++++++++++++++')
-    print('WARNING: SKIP RT is set in the parameters_master file - this is why your code didnt run')
-    print('++++++++++++++++++++++++++++++++++++')
+    else:
+        # Print a message in case that skip_rt debugging flag is set:
+        print('++++++++++++++++++++++++++++++++++++')
+        print('WARNING: SKIP RT is set in the parameters_master file - this is why your code didnt run')
+        print('++++++++++++++++++++++++++++++++++++')
 
 if ds_type in ['gadget_hdf5','tipsy','arepo_hdf5']:
     dump_data(reg, model)

--- a/powderday/enzo_tributary.py
+++ b/powderday/enzo_tributary.py
@@ -60,9 +60,9 @@ def enzo_m_gen(fname,field_add):
    
     boost = np.array([xcent,ycent,zcent])
 
-    dx = ds1.domain_width.in_units('cm')
-    dy = ds1.domain_width.in_units('cm')
-    dz = ds1.domain_width.in_units('cm')
+    dx = ds1.domain_width[0].in_units('cm')
+    dy = ds1.domain_width[1].in_units('cm')
+    dz = ds1.domain_width[2].in_units('cm')
     
     return m,xcent,ycent,zcent,dx,dy,dz,reg,ds1,boost
 


### PR DESCRIPTION
The domain size was unchanged from the whole simulation and region. This overwrites it with the cropped values. Also, the domain_width is a 3-list which was being written to the hyperion model input and caused a segfault (memory corruption) during imaging. Also a small fix in the front end that put the SKIP_RT warning inside an else block.