### PR TITLE
Fix for Issue #111: Added option to turn off CMDF for nebular emission

### DIFF
--- a/docs/parameters_description.rst
+++ b/docs/parameters_description.rst
@@ -261,14 +261,6 @@ Stellar SEDs Info
     
     Add circumstellar AGB dust model (100%); Villaume, Conroy & Jonson 2015
 
-:use_cmdf:    
-    
-    If True, star particles that fit the criteria for nebular emission (see next section) are broken down 
-    using a cluster mass distribution function (cmdf) even if nebular emission is turned off (add_nebular_emission = False). 
-    This allows for one to one comparison of models with and without nebular emission. The cmdf is set by the following 
-    parameters defined under nebular emission info (next section): cmdf_min_mass, cmdf_max_mass, cmdf_bins and cmdf_beta.
-
-
 Nebular Emission Info
 ------------
 
@@ -282,16 +274,21 @@ Nebular Emission Info
     Otherwise CLOUDY models are generated individually for each young star particle. 
     Note:  The lookup tables work only for stars particles below 10 Myr. (Default: True)
 
+:use_cmdf:
+
+    If True, star particles that have mass greater than cmdf_mas_mass (defined below) are broken down using a cluster mass
+    distribution defined as dN/dM goes as M^(beta). This works irrespecitve of whether nebular emission is turned on or not. 
+    The cmdf is set by the following parameters defined below: cmdf_min_mass, cmdf_max_mass, cmdf_bins and cmdf_beta.
+
 :cmdf_min_mass:
 
-    While calulating nebular emission one star particle is broken down into smaller star cluster by
-    assuming a cluster mass distribution function of the form dN/dM goes as M^(-2.0). This parameter 
-    sets the minimum mass of the star clusters in units of log(Msun). Note this value should not be 
-    set lower than 3.5. (Default = 3.5)
+    Minimum mass of the star clusters in units of log(Msun). Note: Results might be inconsistent if
+    set lower than 3.5. (See Chandar et al.2014 for more info) (Default = 3.5)
 
 :cmdf_max_mass:
     
-    Minimum mass of the star clusters in units of log(Msun). (Default = 5.0)
+    Maximum mass of the star clusters in units of log(Msun). (Default = 5.0). Note: Only star particles that
+    have a mass greater than this parameter are broken down.
 
 :cmdf_bins:
 

--- a/parameters_master.py
+++ b/parameters_master.py
@@ -66,11 +66,6 @@ pagb = 1 # weight given to post agb stars# 1 is the default
 
 add_agb_dust_model = False    # add circumstellar AGB dust model (100%); Villaume, Conroy & Jonson 2015
 
-use_cmdf = False     # If True, star particles that fit the criteria for nebular emission (see next section) are broken down 
-                     # using a cluster mass distribution function (cmdf) even if nebular emission is turned off (add_nebular_emission = False). 
-                     # This allows for one to one comparison of models with and without nebular emission. The cmdf is set by the following 
-                     # parameters defined under nebular emission info (next section): cmdf_min_mass, cmdf_max_mass, cmdf_bins and cmdf_beta.
-
 #===============================================
 #NEBULAR EMISSION INFO
 #===============================================
@@ -80,13 +75,16 @@ use_cloudy_tables = True    			    # If True, CLOUDY look up tables (dev. by Nel
                             			    # nebular emission. If False, CLOUDY models are generated individually 
                             			    # for each young star particle (under active development). 
                             			    # Note:  The lookup tables work only for stars particles below 10 Myr.  (Default: True)
+    
+use_cmdf = False                            # If True, star particles that have mass greater than cmdf_mas_mass (defined below) are broken down using a cluster mass distribution function (cmdf) of the form 
+                                            # dN/dM goes as M^(beta). This works irrespecitve of whether nebular emission is turned on or not. 
+                                            # The cmdf is set by the following parameters defined below: cmdf_min_mass, cmdf_max_mass, cmdf_bins and cmdf_beta.
 
-cmdf_min_mass = 3.5                         # While calulating nebular emission from young stars and PAGB stars one star particle is broken down 
-                                            # into smaller star cluster by assuming a cluster mass distribution function of the form dN/dM goes as M^(beta). 
-                                            # This parameter sets the minimum mass of the star clusters in units of log(Msun). Note this value 
-                                            # should not be set lower than 3.5. (Default = 3.5)
+cmdf_min_mass = 3.5                         # Minimum mass of the star clusters in units of log(Msun). Note: Results might be inconsistent if
+                                            # set lower than 3.5. (See Chandar et al.2014 for more info) (Default = 3.5)
 
-cmdf_max_mass = 5.0                         # Minimum mass of the star clusters in units of log(Msun). (Default = 5.0)
+cmdf_max_mass = 5.0                         # Maximum mass of the star clusters in units of log(Msun). (Default = 5.0). Note: Only star particles that
+                                            # have a mass greater than this parameter are broken down. 
 
 cmdf_bins = 6                               # The number of bins used for calulating the cluster mass distribution function (Default = 6.0)
 

--- a/powderday/SED_gen.py
+++ b/powderday/SED_gen.py
@@ -426,8 +426,16 @@ def newstars_gen(stars_list):
 
         if (cfg.par.add_neb_emission or cfg.par.use_cmdf) and (young_star or pagb):
 
-            cluster_mass, num_clusters = cmdf(stars_list[i].mass/constants.M_sun.cgs.value,int(cfg.par.cmdf_bins),cfg.par.cmdf_min_mass,
-                                                cfg.par.cmdf_max_mass, cfg.par.cmdf_beta)
+            # Cluster Mass Distribution Funtion is used only when the star particle's mass is gretaer than the maximum cluster mass and use_cmdf is True. 
+
+            if stars_list[i].mass/constants.M_sun.cgs.value > 10**cfg.par.cmdf_max_mass and cfg.par.use_cmdf:
+                cluster_mass, num_clusters = cmdf(stars_list[i].mass/constants.M_sun.cgs.value,int(cfg.par.cmdf_bins),cfg.par.cmdf_min_mass,
+                        cfg.par.cmdf_max_mass, cfg.par.cmdf_beta)
+            
+            else:
+                cluster_mass = [np.log10(stars_list[i].mass/constants.M_sun.cgs.value)]
+                num_clusters = [1]
+
             f = np.zeros(nlam)
             cloudy_nlam = len(np.genfromtxt(cfg.par.pd_source_dir + "/powderday/nebular_emission/data/refLines.dat", delimiter=','))
             line_em = np.zeros([cloudy_nlam])
@@ -451,7 +459,6 @@ def newstars_gen(stars_list):
                         nh = cfg.par.PAGB_nh    
                         escape_fraction  = cfg.par.PAGB_escape_fraction
 
-                    
                     spec = sp.get_spectrum(tage=stars_list[i].age,zmet=stars_list[i].fsps_zmet)
 
                     alpha = 2.5e-13 # Recombination Rate (assuming T = 10^4 K)


### PR DESCRIPTION
CMDF can now be turned on/off for nebular emission using the use_cmdf parameter. This is different from how use_cmdf was being used before. Also, CMDF now works only the star particles that have a mass greater than cmdf_max_mass.

Please read the docs for more info.


