### PR TITLE
Added nebular emission from Diffused Ionized Gas (DIG)

### DIFF
--- a/docs/parameters_description.rst
+++ b/docs/parameters_description.rst
@@ -349,7 +349,7 @@ NOTE: These parmeters take three values as an input. They correspond to the valu
     use_cloudy_tables = True and FORCE_inner_radius = True (Default: [1.e19,1.e19,2.777e+20])
 
 :FORCE_N_O_Pilyugin:
-    If set, then the Nitrogen abundances are set according to the N/O vs O/H relation form Pilyugin et al. 2012
+    If set, then the Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
     If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored. (Default: [False,False,False])
 
     
@@ -419,9 +419,9 @@ Young Stars
 
 :HII_alpha_enhacement:               
     
-    If set, then the metallicity of star particles to [Fe/H] rather than the total metallicity. 
+    If set, then the metallicity of star particles to [Fe/H] rather than the total metals. 
     Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
-    hardnening to radiaiton field due to alpha-enhancement. (Default: False)
+    hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 Post-AGB stars
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/parameters_description.rst
+++ b/docs/parameters_description.rst
@@ -301,7 +301,8 @@ Nebular Emission Info
 COMMON PARAMETERS
 ~~~~~~~~~~~~~~~~~~~~~~
 
-NOTE: These parmeters take three values as an input. They correspond to the value of the pararmeter for young_stars, Post-AGB stars and AGN respectively.
+NOTE: These parmeters take three or four values as an input. 
+They correspond to the value of the pararmeter for young_stars, Post-AGB stars , AGNs and Diffuse Ionized Gas (DIG) respectively.
 
 :FORCE_gas_logu:
     
@@ -470,7 +471,8 @@ Post-AGB stars
 :PAGB_escape_fraction:	    
 	
 	Fraction of H-ionizaing photons that escape the HII region. 
-    This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
+    This is used only when add_neb_emission = True and use_cloudy_tables = False and
+    add_pagb_stars is set to True (Default = 0.0)
 
 AGN
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -481,15 +483,34 @@ AGN
 
 :AGN_nh:					            
 	
-	Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
-    This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e3)
+	Gas hydrogen density for calcualting nebular emission in units if cm^-3. (Default = 1.e3)
 
 :AGN_num_gas:
 
 	For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 	The number of gas particles used for doing so is set by this parameter. 
 	(Default: 32)
-	
+
+
+DIG
+~~~~~~~~~~~~~~~~~~~~~~
+
+:add_DIG_neb:
+    
+    If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+:DIG_nh:
+
+    Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+:DIG_min_factor:
+
+    For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is set by a parameter called  "Factor". 
+    It is the ratio of total energy dumped in a cell to the total energy of the Black (1987) SED, which we use as the template for setting 
+    the SED shape for calculating DIG emission. This parameter sets the minimum factor that the code uses for calculation. 
+    For example, setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other words ignore all the 
+    cells where the total energy dumped is less than the integrated energy of the Black (1987) SED. (Default: 1)
+
 DEBUGGING AND CLEAN UP
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -517,7 +538,7 @@ DEBUGGING AND CLEAN UP
    Note that in case an error occurs, the files are not deleted even if this value is set to True.
    (Default: True)  
    
-
+   
 Birth Cloud Information
 ------------
 

--- a/front_end_tools.py
+++ b/front_end_tools.py
@@ -1,0 +1,141 @@
+from __future__ import print_function
+from astropy import constants
+from powderday.image_processing import add_transmission_filters, convolve
+from astropy import units as u
+import powderday.config as cfg
+import numpy as np
+
+def make_SED(m, par, model, DIG=False):
+    # set up the SEDs and images
+    
+    if DIG:
+        dig_str = "_DIG"
+    else:
+        dig_str = ""
+
+    if cfg.par.SED_MONOCHROMATIC == True:
+
+        # since all sources have the same spectrum just take the nu
+        # from the input SED from the first source
+
+        monochromatic_nu = m.sources[0].spectrum['nu'] * u.Hz
+        monochromatic_lam = (constants.c / monochromatic_nu).to(u.micron).value[::-1]
+
+        if cfg.par.FIX_SED_MONOCHROMATIC_WAVELENGTHS == True:
+            # idx = np.round(np.linspace(np.min(np.where(monochromatic_lam > cfg.par.SED_MONOCHROMATIC_min_lam)[0]),\
+            ##                           np.max(np.where(monochromatic_lam < cfg.par.SED_MONOCHROMATIC_max_lam)[0]),\
+            #                           cfg.par.SED_MONOCHROMATIC_nlam))
+
+            idx = np.where((monochromatic_lam > cfg.par.SED_MONOCHROMATIC_min_lam) & (
+                        monochromatic_lam < cfg.par.SED_MONOCHROMATIC_max_lam))[0]
+            monochromatic_lam = np.take(monochromatic_lam, list(idx))
+        m.set_monochromatic(True, wavelengths=monochromatic_lam)
+        m.set_raytracing(True)
+        m.set_n_photons(initial=par.n_photons_initial,
+                        imaging_sources=par.n_photons_imaging,
+                        imaging_dust=par.n_photons_imaging,
+                        raytracing_sources=par.n_photons_raytracing_sources,
+                        raytracing_dust=par.n_photons_raytracing_dust)
+
+        m.set_n_initial_iterations(3)
+        m.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
+        sed = m.add_peeled_images(sed=True, image=False)
+
+        if cfg.par.MANUAL_ORIENTATION == True:
+            sed.set_viewing_angles(np.array(cfg.par.THETA), np.array(cfg.par.PHI))
+
+        else:
+            sed.set_viewing_angles(np.linspace(0, 90, par.NTHETA).tolist() * par.NPHI,
+                                   np.repeat(np.linspace(0, 90, par.NPHI), par.NPHI))
+        sed.set_track_origin('basic')
+
+        if cfg.par.SKIP_RT == False:
+            m.write(model.inputfile + '.sed', overwrite=True)
+            m.run(model.outputfile + str(dig_str) + '.sed', mpi=True, n_processes=par.n_MPI_processes, overwrite=True)
+
+        print(
+            '[pd_front_end]: Beginning RT Stage: Calculating SED using a monochromatic spectrum equal to the input SED')
+
+    else:
+
+        m.set_raytracing(True)
+        m.set_n_photons(initial=par.n_photons_initial, imaging=par.n_photons_imaging,
+                        raytracing_sources=par.n_photons_raytracing_sources,
+                        raytracing_dust=par.n_photons_raytracing_dust)
+        m.set_n_initial_iterations(7)
+        m.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
+
+        sed = m.add_peeled_images(sed=True, image=False)
+        sed.set_wavelength_range(2500, 0.001, 1000.)
+
+        if cfg.par.MANUAL_ORIENTATION == True:
+            sed.set_viewing_angles(np.array(cfg.par.THETA), np.array(cfg.par.PHI))
+        else:
+            sed.set_viewing_angles(np.linspace(0, 90, par.NTHETA).tolist(
+            ) * par.NPHI, np.repeat(np.linspace(0, 90, par.NPHI), par.NPHI))
+        sed.set_track_origin('basic')
+
+        print('[pd_front_end]: Beginning RT Stage: Calculating SED using a binned spectrum')
+
+        # Run the Model
+        if cfg.par.SKIP_RT == False:
+            m.write(model.inputfile + '.sed', overwrite=True)
+            m.run(model.outputfile + '.sed', mpi=True,
+                  n_processes=par.n_MPI_processes, overwrite=True)
+
+
+def make_image(m ,par, model):
+    print("Beginning Monochromatic Imaging RT")
+
+    if cfg.par.IMAGING_TRANSMISSION_FILTER == False:
+
+        # read in the filters file
+        try:
+            filter_data = [np.loadtxt(par.filterdir + f) for f in par.filterfiles]
+        except:
+            raise ValueError(
+                "Filters not found. You may be running above changeset 'f1f16eb' with an outdated parameters_master file. Please update to the most recent parameters_master format or ensure that the 'filterdir' and 'filterfiles' parameters are set properly.")
+
+        # Extract and flatten all wavelengths in the filter files
+        wavs = [wav[0] for single_filter in filter_data for wav in single_filter]
+        wavs = list(set(wavs))  # Remove duplicates, if they exist
+
+        m_imaging.set_monochromatic(True, wavelengths=wavs)
+        m_imaging.set_raytracing(True)
+        m_imaging.set_n_photons(initial=par.n_photons_initial,
+                                imaging_sources=par.n_photons_imaging,
+                                imaging_dust=par.n_photons_imaging,
+                                raytracing_sources=par.n_photons_raytracing_sources,
+                                raytracing_dust=par.n_photons_raytracing_dust)
+    else:
+        m_imaging.set_n_photons(initial=par.n_photons_initial, imaging=par.n_photons_imaging)
+
+    m_imaging.set_n_initial_iterations(7)
+    m_imaging.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
+
+    image = m_imaging.add_peeled_images(sed=True, image=True)
+
+    if cfg.par.IMAGING_TRANSMISSION_FILTER == True:
+        add_transmission_filters(image)
+
+    if cfg.par.MANUAL_ORIENTATION == True:
+        image.set_viewing_angles(np.array(cfg.par.THETA), np.array(cfg.par.PHI))
+    else:
+        image.set_viewing_angles(np.linspace(0, 90, par.NTHETA).tolist() * par.NPHI,
+                                 np.repeat(np.linspace(0, 90, par.NPHI), par.NPHI))
+
+    image.set_track_origin('basic')
+    image.set_image_size(cfg.par.npix_x, cfg.par.npix_y)
+    image.set_image_limits(-dx / 2., dx / 2., -dy / 2., dy / 2.)
+
+    if cfg.par.SKIP_RT == False:
+        m_imaging.write(model.inputfile + '.image', overwrite=True)
+        m_imaging.run(model.outputfile + '.image', mpi=True, n_processes=par.n_MPI_processes, overwrite=True)
+
+        convolve(model.outputfile + '.image', par.filterfiles, filter_data)
+    else:
+        # Print a message in case that skip_rt debugging flag is set:
+        print('++++++++++++++++++++++++++++++++++++')
+        print('WARNING: SKIP RT is set in the parameters_master file - this is why your code didnt run')
+        print('++++++++++++++++++++++++++++++++++++')
+        

--- a/parameters_master.py
+++ b/parameters_master.py
@@ -139,7 +139,7 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation form Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the Nitrogen abundance such that the log of N/O ratio is N_O_ratio (next parameter). 
@@ -190,9 +190,9 @@ HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
-HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to [Fe/H] rather than the total metallicity. 
-                                            # Since FSPS does not support non solar abundance ratios. This parameter can be used to mimic the 
-                                            # hardnening to radiaiton field due to alpha-enhancement. (Default: False)
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to [Fe/H] rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiation field due to alpha-enhancement. (Default: False)
 
 #****************
 # Post-AGB STARS

--- a/parameters_master.py
+++ b/parameters_master.py
@@ -107,7 +107,8 @@ cmdf_beta = -2.0                            # Beta (power law exponent) for calc
 #**********************
 # COMMON PARAMETERS
 #***********************
-# NOTE: These parmeters take three values as an input. They correspond to the value of the pararmeter for young_stars, PAGB stars and AGN respectively.
+# NOTE: These parmeters take either three or four values as an input. 
+# They correspond to the value of the pararmeter for young_stars, PAGB stars, AGN and DIG respectively.
 
 FORCE_gas_logu = [False, False, False] 	    # If set, then we force the ionization parameter (gas_logu) to be 
                             			    # gas_logu (next parameter) else, it is taken to be variable and dependent on ionizing 
@@ -139,32 +140,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
-                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                                   # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False, False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the Nitrogen abundance such that the log of N/O ratio is N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]     # If set, then we force the Nitrogen abundance such that the log of N/O ratio is N_O_ratio (next parameter). 
+                            			           # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			           # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
-
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundances from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+neb_abund = ["dopita", "dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundances from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
 #***************************
 # YOUNG STARS (HII regions)
 #***************************
@@ -234,7 +230,25 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
-											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+			            					# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 1                          # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+
+
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -398,3 +412,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/pd_front_end.py
+++ b/pd_front_end.py
@@ -5,7 +5,8 @@
 # IMPORT STATEMENTS
 # =========================================================
 from __future__ import print_function
-from powderday.source_creation import direct_add_stars, add_binned_seds, BH_source_add
+from front_end_tools import make_SED, make_image
+from powderday.source_creation import direct_add_stars, add_binned_seds, BH_source_add, DIG_source_add
 from powderday.analytics import stellar_sed_write, dump_data, SKIRT_data_dump, logu_diagnostic,dump_emlines
 from astropy import constants
 import fsps
@@ -52,7 +53,7 @@ eh.file_exist(par.dustdir+par.dustfile)
 # =========================================================
 # Enforce Backwards Compatibility for Non-Critical Variables
 # =========================================================
-cfg.par.FORCE_RANDOM_SEED, cfg.par.FORCE_BINNED, cfg.par.max_age_direct, cfg.par.imf1, cfg.par.imf2, cfg.par.imf3, cfg.par.use_cmdf, cfg.par.use_cloudy_tables, cfg.par.cmdf_min_mass, cfg.par.cmdf_max_mass, cfg.par.cmdf_bins, cfg.par.cmdf_beta, cfg.par.FORCE_gas_logu, cfg.par.gas_logu, cfg.par.gas_logu_init, cfg.par.FORCE_gas_logz, cfg.par.gas_logz, cfg.par.FORCE_logq, cfg.par.source_logq, cfg.par.FORCE_inner_radius, cfg.par.inner_radius, cfg.par.FORCE_N_O_Pilyugin, cfg.par.FORCE_N_O_ratio, cfg.par.N_O_ratio, cfg.par.neb_abund, cfg.par.add_young_stars, cfg.par.HII_Rinner_per_Rs, cfg.par.HII_nh, cfg.par.HII_min_age, cfg.par.HII_max_age, cfg.par.HII_escape_fraction, cfg.par.HII_alpha_enhance, cfg.par.add_pagb_stars, cfg.par.PAGB_min_age, cfg.par.PAGB_max_age, cfg.par.PAGB_N_enhancement, cfg.par.PAGB_C_enhancement, cfg.par.PAGB_Rinner_per_Rs, cfg.par.PAGB_nh, cfg.par.PAGB_escape_fraction, cfg.par.add_AGN_neb, cfg.par.AGN_nh, cfg.par.AGN_num_gas, cfg.par.dump_emlines, cfg.par.cloudy_cleanup, cfg.par.BH_SED, cfg.par.IMAGING, cfg.par.SED, cfg.par.IMAGING_TRANSMISSION_FILTER, cfg.par.SED_MONOCHROMATIC, cfg.par.SKIP_RT, cfg.par.FIX_SED_MONOCHROMATIC_WAVELENGTHS, cfg.par.n_MPI_processes, cfg.par.SOURCES_RANDOM_POSITIONS, cfg.par.SUBLIMATION, cfg.par.SUBLIMATION_TEMPERATURE, cfg.model.TCMB, cfg.model.THETA, cfg.model.PHI, cfg.par.MANUAL_ORIENTATION, cfg.par.solar, cfg.par.dust_grid_type, cfg.par.BH_model, cfg.par.BH_modelfile, cfg.par.BH_var, cfg.par.FORCE_STELLAR_AGES,cfg.par.FORCE_STELLAR_AGES_VALUE, cfg.par.FORCE_STELLAR_METALLICITIES, cfg.par.FORCE_STELLAR_METALLICITIES_VALUE, cfg.par.NEB_DEBUG, cfg.par.filterdir, cfg.par.filterfiles,  cfg.par.PAH_frac, cfg.par.otf_extinction, cfg.par.explicit_pah = bc.variable_set()
+cfg.par.FORCE_RANDOM_SEED, cfg.par.FORCE_BINNED, cfg.par.max_age_direct, cfg.par.imf1, cfg.par.imf2, cfg.par.imf3, cfg.par.use_cmdf, cfg.par.use_cloudy_tables, cfg.par.cmdf_min_mass, cfg.par.cmdf_max_mass, cfg.par.cmdf_bins, cfg.par.cmdf_beta, cfg.par.FORCE_gas_logu, cfg.par.gas_logu, cfg.par.gas_logu_init, cfg.par.FORCE_gas_logz, cfg.par.gas_logz, cfg.par.FORCE_logq, cfg.par.source_logq, cfg.par.FORCE_inner_radius, cfg.par.inner_radius, cfg.par.FORCE_N_O_Pilyugin, cfg.par.FORCE_N_O_ratio, cfg.par.N_O_ratio, cfg.par.neb_abund, cfg.par.add_young_stars, cfg.par.HII_Rinner_per_Rs, cfg.par.HII_nh, cfg.par.HII_min_age, cfg.par.HII_max_age, cfg.par.HII_escape_fraction, cfg.par.HII_alpha_enhance, cfg.par.add_pagb_stars, cfg.par.PAGB_min_age, cfg.par.PAGB_max_age, cfg.par.PAGB_N_enhancement, cfg.par.PAGB_C_enhancement, cfg.par.PAGB_Rinner_per_Rs, cfg.par.PAGB_nh, cfg.par.PAGB_escape_fraction, cfg.par.add_AGN_neb, cfg.par.AGN_nh, cfg.par.AGN_num_gas, cfg.par.dump_emlines, cfg.par.cloudy_cleanup, cfg.par.BH_SED, cfg.par.IMAGING, cfg.par.SED, cfg.par.IMAGING_TRANSMISSION_FILTER, cfg.par.SED_MONOCHROMATIC, cfg.par.SKIP_RT, cfg.par.FIX_SED_MONOCHROMATIC_WAVELENGTHS, cfg.par.n_MPI_processes, cfg.par.SOURCES_RANDOM_POSITIONS, cfg.par.SUBLIMATION, cfg.par.SUBLIMATION_TEMPERATURE, cfg.model.TCMB, cfg.model.THETA, cfg.model.PHI, cfg.par.MANUAL_ORIENTATION, cfg.par.solar, cfg.par.dust_grid_type, cfg.par.BH_model, cfg.par.BH_modelfile, cfg.par.BH_var, cfg.par.FORCE_STELLAR_AGES,cfg.par.FORCE_STELLAR_AGES_VALUE, cfg.par.FORCE_STELLAR_METALLICITIES, cfg.par.FORCE_STELLAR_METALLICITIES_VALUE, cfg.par.NEB_DEBUG, cfg.par.filterdir, cfg.par.filterfiles,  cfg.par.PAH_frac, cfg.par.otf_extinction, cfg.par.explicit_pah, cfg.par.add_DIG_neb, cfg.par.DIG_nh, cfg.par.DIG_min_factor, cfg.par.DIFF_DIG_SED = bc.variable_set()
 # =========================================================
 # GRIDDING
 # =========================================================
@@ -98,8 +99,7 @@ N_METAL_BINS = len(fsps_metals)
 
 #initializing the nebular diagnostic file newly
 if cfg.par.add_neb_emission and cfg.par.NEB_DEBUG: logu_diagnostic(None,None,None,None,None,None,None,append=False)
-if cfg.par.add_neb_emission and cfg.par.dump_emlines: dump_emlines(None,None,append=False)
-
+if cfg.par.add_neb_emission and cfg.par.dump_emlines: dump_emlines(None,None,None,append=False)
 
 if cfg.par.BH_SED == True:
     BH_source_add(m, reg, df_nu, boost)
@@ -186,130 +186,19 @@ print('Setting up Model')
 m_imaging = copy.deepcopy(m)
 m.conf.output.output_specific_energy = 'last'
 
-
-if cfg.par.SED == True:
-    # set up the SEDs and images
-
-    if cfg.par.SED_MONOCHROMATIC == True:
-
-         # since all sources have the same spectrum just take the nu
-         # from the input SED from the first source
-
-        monochromatic_nu = m.sources[0].spectrum['nu']*u.Hz
-        monochromatic_lam = (constants.c/monochromatic_nu).to(u.micron).value[::-1]
-
-        if cfg.par.FIX_SED_MONOCHROMATIC_WAVELENGTHS == True:
-            # idx = np.round(np.linspace(np.min(np.where(monochromatic_lam > cfg.par.SED_MONOCHROMATIC_min_lam)[0]),\
-            ##                           np.max(np.where(monochromatic_lam < cfg.par.SED_MONOCHROMATIC_max_lam)[0]),\
-            #                           cfg.par.SED_MONOCHROMATIC_nlam))
-
-            idx = np.where((monochromatic_lam > cfg.par.SED_MONOCHROMATIC_min_lam) & (monochromatic_lam < cfg.par.SED_MONOCHROMATIC_max_lam))[0]
-            monochromatic_lam = np.take(monochromatic_lam, list(idx))
-        m.set_monochromatic(True, wavelengths=monochromatic_lam)
-        m.set_raytracing(True)
-        m.set_n_photons(initial=par.n_photons_initial,
-                        imaging_sources=par.n_photons_imaging,
-                        imaging_dust=par.n_photons_imaging,
-                        raytracing_sources=par.n_photons_raytracing_sources,
-                        raytracing_dust=par.n_photons_raytracing_dust)
-
-        m.set_n_initial_iterations(3)
-        m.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
-        sed = m.add_peeled_images(sed=True, image=False)
-
-        if cfg.par.MANUAL_ORIENTATION == True:
-            sed.set_viewing_angles(np.array(cfg.par.THETA), np.array(cfg.par.PHI))
-
-        else:
-            sed.set_viewing_angles(np.linspace(0, 90, par.NTHETA).tolist()*par.NPHI, np.repeat(np.linspace(0, 90, par.NPHI), par.NPHI))
-        sed.set_track_origin('basic')
-
-        if cfg.par.SKIP_RT == False:
-            m.write(model.inputfile+'.sed', overwrite=True)
-            m.run(model.outputfile+'.sed', mpi=True, n_processes=par.n_MPI_processes, overwrite=True)
-
-        print('[pd_front_end]: Beginning RT Stage: Calculating SED using a monochromatic spectrum equal to the input SED')
-
-    else:
-
-        m.set_raytracing(True)
-        m.set_n_photons(initial=par.n_photons_initial, imaging=par.n_photons_imaging, raytracing_sources=par.n_photons_raytracing_sources, raytracing_dust=par.n_photons_raytracing_dust)
-        m.set_n_initial_iterations(7)
-        m.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
-
-        sed = m.add_peeled_images(sed=True, image=False)
-        sed.set_wavelength_range(2500, 0.001, 1000.)
-
-        if cfg.par.MANUAL_ORIENTATION == True:
-            sed.set_viewing_angles(np.array(cfg.par.THETA), np.array(cfg.par.PHI))
-        else:
-            sed.set_viewing_angles(np.linspace(0, 90, par.NTHETA).tolist(
-            )*par.NPHI, np.repeat(np.linspace(0, 90, par.NPHI), par.NPHI))
-        sed.set_track_origin('basic')
-
-        print('[pd_front_end]: Beginning RT Stage: Calculating SED using a binned spectrum')
-       
-        # Run the Model
-        if cfg.par.SKIP_RT == False:
-            m.write(model.inputfile+'.sed', overwrite=True)
-            m.run(model.outputfile+'.sed', mpi=True,
-                  n_processes=par.n_MPI_processes, overwrite=True)
-
-# see if the variable exists to make code backwards compatible
-
-if cfg.par.IMAGING == True:
-
-    print("Beginning Monochromatic Imaging RT")
-
-    if cfg.par.IMAGING_TRANSMISSION_FILTER == False:
-
-        # read in the filters file
-        try:
-            filter_data = [np.loadtxt(par.filterdir+f) for f in par.filterfiles]
-        except:
-            raise ValueError("Filters not found. You may be running above changeset 'f1f16eb' with an outdated parameters_master file. Please update to the most recent parameters_master format or ensure that the 'filterdir' and 'filterfiles' parameters are set properly.")
-
-        # Extract and flatten all wavelengths in the filter files
-        wavs = [wav[0] for single_filter in filter_data for wav in single_filter]
-        wavs = list(set(wavs))      # Remove duplicates, if they exist
-
-        m_imaging.set_monochromatic(True, wavelengths=wavs)
-        m_imaging.set_raytracing(True)
-        m_imaging.set_n_photons(initial=par.n_photons_initial,
-                                imaging_sources=par.n_photons_imaging,
-                                imaging_dust=par.n_photons_imaging,
-                                raytracing_sources=par.n_photons_raytracing_sources,
-                                raytracing_dust=par.n_photons_raytracing_dust)
-    else:
-        m_imaging.set_n_photons(initial=par.n_photons_initial, imaging=par.n_photons_imaging)
-
-    m_imaging.set_n_initial_iterations(7)
-    m_imaging.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
-
-    image = m_imaging.add_peeled_images(sed=True, image=True)
-
-    if cfg.par.IMAGING_TRANSMISSION_FILTER == True:
-        add_transmission_filters(image)
-
-    if cfg.par.MANUAL_ORIENTATION == True:
-        image.set_viewing_angles(np.array(cfg.par.THETA), np.array(cfg.par.PHI))
-    else:
-        image.set_viewing_angles(np.linspace(0, 90, par.NTHETA).tolist()*par.NPHI, np.repeat(np.linspace(0, 90, par.NPHI), par.NPHI))
-
-    image.set_track_origin('basic')
-    image.set_image_size(cfg.par.npix_x, cfg.par.npix_y)
-    image.set_image_limits(-dx/2., dx/2., -dy/2., dy/2.)
-
-    if cfg.par.SKIP_RT == False:
-        m_imaging.write(model.inputfile+'.image', overwrite=True)
-        m_imaging.run(model.outputfile+'.image', mpi=True, n_processes=par.n_MPI_processes, overwrite=True)
-
-        convolve(model.outputfile+'.image', par.filterfiles, filter_data)
-    else:
-        # Print a message in case that skip_rt debugging flag is set:
-        print('++++++++++++++++++++++++++++++++++++')
-        print('WARNING: SKIP RT is set in the parameters_master file - this is why your code didnt run')
-        print('++++++++++++++++++++++++++++++++++++')
+if cfg.par.SED:
+    make_SED(m, par, model)
 
 if ds_type in ['gadget_hdf5','tipsy','arepo_hdf5']:
-    dump_data(reg, model)
+        dump_data(reg, model)
+
+if cfg.par.add_neb_emission and cfg.par.add_DIG_neb:
+    DIG_source_add(m, reg, df_nu)
+    
+    if cfg.par.DIFF_DIG_SED:
+        make_SED(m, par, model, DIG=True)
+    else:
+        make_SED(m, par, model)
+
+if cfg.par.IMAGING:
+    make_image(m, par, model)

--- a/powderday/SED_gen.py
+++ b/powderday/SED_gen.py
@@ -461,8 +461,19 @@ def newstars_gen(stars_list):
 
                     if cfg.par.HII_alpha_enhance: #Setting Zstar based on Fe/H 
                         Fe = stars_list[i].all_metals[-1]
-                        FeH = (Fe/0.7314)*(1.008/55.845)
+
+                        # Gizmo metallicity structure, photospheric abundances from Asplund et al. 2009:
+                        # Photospheric mass fraction of H = 0.7381
+                        # Photospheric mass fraction of Fe = 1.31e-3
+
+                        # Converting from mass fraction to atomic fraction of Fe
+                        # Taking atmoic mass of H = 1.008u
+                        # Taking atmoic mass of Fe = 55.845u
+                        FeH = (Fe/0.7381)*(1.008/55.845)
+
+                        # Solar atomic fraction of Fe. Calculated by substituting Fe = 1.31e-3 in the previous equation
                         FeH_sol = 3.22580645e-5
+
                         Logzsol = np.log10(FeH/FeH_sol)
                         
                         sp1 = fsps.StellarPopulation(zcontinuous=1)

--- a/powderday/SED_gen.py
+++ b/powderday/SED_gen.py
@@ -28,7 +28,6 @@ gc.set_threshold(0)
 
 # Lazily initialize FSPS
 sp = None
-reg_gl = None
 
 class Stars:
     def __init__(self,mass,metals,positions,age,sed_bin=[-1,-1,-1],lum=-1,fsps_zmet=20,all_metals=[-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1]):
@@ -45,10 +44,6 @@ class Stars:
         return(self.mass,self.metals,self.positions,self.age,self.sed_bin,self.lum,self.fsps_zmet)
 
 def star_list_gen(boost,dx,dy,dz,reg,ds):
-    global reg_gl
-    if reg_gl is None:
-        reg_gl = reg
-
     print ('[SED_gen/star_list_gen]: reading in stars particles for SPS calculation')
     mass = reg["starmasses"].value
     positions = reg["starcoordinates"].value
@@ -524,7 +519,7 @@ def newstars_gen(stars_list):
                         LogZ = cfg.par.gas_logz[id_val]
                     
                     else:
-                        LogZ = np.log10(metals[0]/cfg.par.solar)
+                        LogZ = np.log10(stars_list[i].metals/cfg.par.solar)
 
 
                     if neb_file_output:
@@ -610,9 +605,12 @@ def get_gas_metals(ngas):
 def get_nearest_gas_metals(all_gas_coordinates, particle_coordinates):
 
     all_gas_metals = get_gas_metals(len(all_gas_coordinates))
+    
     # Getting N nearest gas particles to the AGN where N is defined by cfg.par.AGN_num_gas
     nearest_gas_dist, nearest_gas_id = get_nearest(all_gas_coordinates, particle_coordinates, num=cfg.par.AGN_num_gas)
+    
     metals_avg = []
+    
     # We take the distance weighted avearge of the metallicity of nearest N gas particles.
     # This is used as input to the CLOUDY model.
     for q in range(11):
@@ -622,15 +620,28 @@ def get_nearest_gas_metals(all_gas_coordinates, particle_coordinates):
     return metals_avg
                                                                                                                 
 
-def get_agn_seds(agn_ids):
+def get_agn_seds(agn_ids, reg):
   
     print ('Starting AGN SED generation')
     
     t1 = datetime.now()
     nprocesses = np.min([cfg.par.n_processes,len(agn_ids)])
     p = Pool(processes = nprocesses)
-    fnu = p.map(agn_sed, agn_ids)
-    fnu = np.atleast_2d(fnu)
+
+    # Pre-calculating average metallicity and fluxes for all the BH particles
+    nu = []
+    fnu_in = []
+    metals_avg = []
+    for agn_id in agn_ids:
+        fnu_in.append(reg["bhsed"][agn_id,:].in_units("Lsun").value/reg["bhnu"].in_units("Hz").value)
+        nu.append(reg["bhnu"].in_units("Hz").value)
+        all_gas_coordinates = reg["gascoordinates"].in_units('kpc').value
+        agn_coordinates = reg["bhcoordinates"][agn_id].in_units('kpc').value
+        metals_avg.append(get_nearest_gas_metals(all_gas_coordinates, agn_coordinates))
+
+    z = zip(agn_ids, nu, fnu_in, metals_avg)
+    fnu_out = p.starmap(agn_sed, z)
+    fnu_out = np.atleast_2d(fnu_out)
     p.close()
     p.terminate()
     p.join()
@@ -638,14 +649,11 @@ def get_agn_seds(agn_ids):
 
     print ('Execution time for AGN SED generation = '+str(t2-t1))
     
-    return fnu
+    return fnu_out
 
 
-def agn_sed(agn_id):
+def agn_sed(agn_id, nu, fnu, metals_avg):
     agn_id = int(agn_id)
-    reg = reg_gl
-    nu = reg["bhnu"].in_units("Hz").value
-    fnu = reg["bhsed"][agn_id,:].in_units("Lsun").value/nu
 
     # Hopkins model returns the nu and fnu in reversed order. 
     # Thus, we have to reverse it back to make it compatible.
@@ -656,15 +664,10 @@ def agn_sed(agn_id):
     if cfg.par.add_neb_emission and cfg.par.add_AGN_neb:
         
         id_val = 2
-
-        all_gas_coordinates = reg["gascoordinates"].in_units('kpc').value
-        agn_coordinates = reg["bhcoordinates"][agn_id].in_units('kpc').value
-        
-        metals_avg = get_nearest_gas_metals(all_gas_coordinates, agn_coordinates)
-                
+            
         tot_metals = metals_avg[0]
         metals = metals_avg
-
+        
         if cfg.par.FORCE_gas_logz[id_val]:
             LogZ = gas_logz[id_val]
         
@@ -686,13 +689,13 @@ def agn_sed(agn_id):
             LogU = np.log10((10**LogQ)/(4*np.pi*Rin*Rin*cfg.par.AGN_nh*constants.c.cgs.value))+cfg.par.gas_logu_init[id_val]
             LogQ = np.log10((10**LogU)*(4*np.pi*Rin*Rin*cfg.par.AGN_nh*constants.c.cgs.value))
 
-        
         spec, wave_line, line_lum = get_nebular(1.e8 * constants.c.cgs.value / nu, fnu, cfg.par.AGN_nh, LogQ, Rin, LogU, LogZ, LogQ, metals,
                                         Dust=False, abund=cfg.par.neb_abund[id_val],clean_up = cfg.par.cloudy_cleanup, index=id_val)
 
         if cfg.par.dump_emlines:
-        # The stellar population returns the calculation in units of Lsun/1 Msun: https://github.com/dfm/python-fsps/issues/117#issuecomment-546513619
+        # The stellar population returns the calculation in units of Lsun
             line_em = line_lum * 3.839e33  # Units: ergs/s
+            # The last column in dump_emlines is reserved for age of the star particle. For AGN we just set it to -1 as a place holder.
             line_em = np.append(line_em, -1.0)
             dump_emlines(wave_line, line_em)
 

--- a/powderday/SED_gen.py
+++ b/powderday/SED_gen.py
@@ -559,8 +559,9 @@ def newstars_gen(stars_list):
                                     efrac=escape_fraction) 
                             #LogQ_1 = LogQ_1 + cfg.par.gas_logu_init[id_val]
                                
-                            spec_neb, wave_line, line_lum = get_nebular(spec[0], spec[1], nh, LogQ, Rin, LogU, LogZ, LogQ_1, stars_list[i].all_metals, 
-                                                    Dust=False, abund=cfg.par.neb_abund[id_val], clean_up = cfg.par.cloudy_cleanup, index=id_val)
+                            spec_neb, wave_line, line_lum = get_nebular(spec[0], spec[1], nh, stars_list[i].all_metals, logq = LogQ, radius = Rin, 
+                                                    logu = LogU, logz = LogZ, logq_1 = LogQ_1, Dust=False, abund=cfg.par.neb_abund[id_val], 
+                                                    clean_up = cfg.par.cloudy_cleanup, index=id_val)
                         except ValueError as err:
                             # If the CLOUDY run crashes we switch to using lookup tables for young stars but throw an error for post-AGB stars.
                             if  young_star:
@@ -586,7 +587,7 @@ def newstars_gen(stars_list):
                 #the stellar population returns the calculation in units of Lsun/1 Msun: https://github.com/dfm/python-fsps/issues/117#issuecomment-546513619
                 line_em = line_em * ((stars_list[i].mass*u.g).to(u.Msun).value) * (3.839e33)  # Units: ergs/s
                 line_em = np.append(line_em, stars_list[i].age)
-                dump_emlines(wave_line, line_em)
+                dump_emlines(wave_line, line_em, id_val)
 
         stellar_nu[:] = 1.e8*constants.c.cgs.value/spec[0]
         stellar_fnu[i,:] = f
@@ -635,6 +636,9 @@ def get_agn_seds(agn_ids, reg):
   
     print ('Starting AGN SED generation')
     
+    if cfg.par.dump_emlines:
+        dump_emlines(None, None, 2, add_header=True)
+
     t1 = datetime.now()
     nprocesses = np.min([cfg.par.n_processes,len(agn_ids)])
     p = Pool(processes = nprocesses)
@@ -700,19 +704,61 @@ def agn_sed(agn_id, nu, fnu, metals_avg):
             LogU = np.log10((10**LogQ)/(4*np.pi*Rin*Rin*cfg.par.AGN_nh*constants.c.cgs.value))+cfg.par.gas_logu_init[id_val]
             LogQ = np.log10((10**LogU)*(4*np.pi*Rin*Rin*cfg.par.AGN_nh*constants.c.cgs.value))
 
-        spec, wave_line, line_lum = get_nebular(1.e8 * constants.c.cgs.value / nu, fnu, cfg.par.AGN_nh, LogQ, Rin, LogU, LogZ, LogQ, metals,
-                                        Dust=False, abund=cfg.par.neb_abund[id_val],clean_up = cfg.par.cloudy_cleanup, index=id_val)
+        spec, wave_line, line_lum = get_nebular(1.e8 * constants.c.cgs.value / nu, fnu, cfg.par.AGN_nh, metals, logq = LogQ, radius = Rin, logu = LogU, 
+                                        logz = LogZ, logq_1 = LogQ, Dust=False, abund=cfg.par.neb_abund[id_val],clean_up = cfg.par.cloudy_cleanup, index=id_val)
 
         if cfg.par.dump_emlines:
         # The stellar population returns the calculation in units of Lsun
             line_em = line_lum * 3.839e33  # Units: ergs/s
             # The last column in dump_emlines is reserved for age of the star particle. For AGN we just set it to -1 as a place holder.
             line_em = np.append(line_em, -1.0)
-            dump_emlines(wave_line, line_em)
+            dump_emlines(wave_line, line_em, id_val)
 
     else:
         spec = fnu
 
+    return spec
+
+
+def get_dig_seds(factors, cell_widths, metals):
+
+    print ('Starting DIG SED generation')
+    
+    t1 = datetime.now()
+    nprocesses = np.min([cfg.par.n_processes,len(cell_widths)])
+    p = Pool(processes = nprocesses)
+
+    z = zip(factors, cell_widths, metals)
+    fnu_out = p.starmap(dig_sed, z)
+    fnu_out = np.atleast_2d(fnu_out)
+    
+    p.close()
+    p.terminate()
+    p.join()
+    t2 = datetime.now()
+
+    print ('Execution time for DIG SED generation = '+str(t2-t1))
+
+    return fnu_out
+
+
+def dig_sed(factor, cell_width, metal):    
+    id_val = 3
+    
+    dat = np.load(cfg.par.pd_source_dir + "/powderday/nebular_emission/data/black_1987.npz")
+    spec_lam = dat["lam"]
+    sspi = dat["sed"]*(cell_width**2)*factor # Lsun/Hz
+    
+    spec, wave_line, line_lum = get_nebular(spec_lam, sspi, cfg.par.DIG_nh, metal, Factor=factor, Cell_width=cell_width, Dust=False,
+                                            abund=cfg.par.neb_abund[id_val], clean_up = cfg.par.cloudy_cleanup, index=id_val)
+
+    if cfg.par.dump_emlines:
+        # The stellar population returns the calculation in units of Lsun
+        line_em = line_lum * 3.839e33  # Units: ergs/s
+        # The last column in dump_emlines is reserved for age of the star particle. For DIG we just set it to -1 as a place holder.
+        line_em = np.append(line_em, -1.0)
+        dump_emlines(wave_line, line_em, id_val)
+        
     return spec
 
 

--- a/powderday/analytics.py
+++ b/powderday/analytics.py
@@ -69,11 +69,11 @@ def stellar_sed_write(m):
    
 
 def dump_cell_info(refined,fc1,fw1,xmin,xmax,ymin,ymax,zmin,zmax):
-    outfile = cfg.model.PD_output_dir+"cell_info."+cfg.model.snapnum_str+".npz"
+    outfile = cfg.model.PD_output_dir+"cell_info."+cfg.model.snapnum_str+"_"+cfg.model.galaxy_num_str+".npz"
     np.savez(outfile,refined=refined,fc1=fc1,fw1=fw1,xmin=xmin,xmax=xmax,ymin=ymin,ymax=ymax,zmin=zmin,zmax=zmax)
 
 def dump_data(reg,model):
-
+    
     particle_fh2 = reg["gasfh2"]
     particle_fh1 = np.ones(len(particle_fh2))-particle_fh2
     particle_gas_mass = reg["gasmasses"]
@@ -87,8 +87,15 @@ def dump_data(reg,model):
     #these are in try/excepts in case we're not dealing with gadget and yt 3.x
     try: grid_gas_mass = reg["gassmoothedmasses"]
     except: grid_gas_mass = -1
-    try: grid_gas_metallicity = reg["gassmoothedmetals"]
+    try: 
+        grid_gas_metallicity = []
+        grid_gas_metallicity.append(reg["gassmoothedmetals"].value)
+        abund_el = ['He', 'C', 'N', 'O', 'Ne', 'Mg', 'Si', 'S', 'Ca', 'Fe']
+        for i in abund_el:
+            grid_gas_metallicity.append(reg["gassmoothedmetals_"+str(i)].value)
+
     except: grid_gas_metallicity = -1
+
     try: grid_star_mass = reg["starsmoothedmasses"]
     except: grid_star_mass = -1
 
@@ -219,7 +226,7 @@ def logu_diagnostic(logQ, LogU, LogZ, Rin, cluster_mass, num_cluster, age, appen
 
 
 # Dumps emission lines
-def dump_emlines(line_wav, line_em, append=True):
+def dump_emlines(line_wav, line_em, id_val, append=True):
     if hasattr(cfg.model, 'galaxy_num_str'):
         outfile_lines = cfg.model.PD_output_dir + "emlines.galaxy" + cfg.model.galaxy_num_str + ".txt"
     else:
@@ -232,7 +239,9 @@ def dump_emlines(line_wav, line_em, append=True):
         f = open(outfile_lines,'a+')
         if os.stat(outfile_lines).st_size == 0:
             np.savetxt(f,np.expand_dims(line_wav,axis=0))
+        
         np.savetxt(f,np.expand_dims(line_em,axis=0))
+        
         f.close()
 
 # Dumps AGN SEDs

--- a/powderday/backwards_compatibility.py
+++ b/powderday/backwards_compatibility.py
@@ -123,28 +123,28 @@ def variable_set():
 
     try:
         if len(np.atleast_1d(cfg.par.FORCE_N_O_Pilyugin)) == 1:
-            cfg.par.FORCE_N_O_Pilyugin = [cfg.par.FORCE_N_O_Pilyugin,cfg.par.FORCE_N_O_Pilyugin,cfg.par.FORCE_N_O_Pilyugin]
+            cfg.par.FORCE_N_O_Pilyugin = [cfg.par.FORCE_N_O_Pilyugin,cfg.par.FORCE_N_O_Pilyugin,cfg.par.FORCE_N_O_Pilyugin, cfg.par.FORCE_N_O_Pilyugin]
     except:
-            cfg.par.FORCE_N_O_Pilyugin = [False, False, False]
+            cfg.par.FORCE_N_O_Pilyugin = [False, False, False, False]
     
     try:
         if len(np.atleast_1d(cfg.par.FORCE_N_O_ratio)) == 1:
-            cfg.par.FORCE_N_O_ratio = [cfg.par.FORCE_N_O_ratio,cfg.par.FORCE_N_O_ratio,cfg.par.FORCE_N_O_ratio]
+            cfg.par.FORCE_N_O_ratio = [cfg.par.FORCE_N_O_ratio,cfg.par.FORCE_N_O_ratio,cfg.par.FORCE_N_O_ratio, cfg.par.FORCE_N_O_ratio]
     except:
-        cfg.par.FORCE_N_O_ratio = [False, False, False]
+        cfg.par.FORCE_N_O_ratio = [False, False, False, False]
         
     try:
         if len(np.atleast_1d(cfg.par.N_O_ratio)) == 1:
-            cfg.par.N_O_ratio = [cfg.par.N_O_ratio,cfg.par.N_O_ratio,cfg.par.N_O_ratio]
+            cfg.par.N_O_ratio = [cfg.par.N_O_ratio,cfg.par.N_O_ratio,cfg.par.N_O_ratio,cfg.par.N_O_ratio]
     except:
-        cfg.par.N_O_ratio = [-0.85,-0.85,-0.85]
+        cfg.par.N_O_ratio = [-0.85,-0.85,-0.85, -0.85]
 
 
     try:
         if len(np.atleast_1d(cfg.par.neb_abund)) == 1:
-            cfg.par.neb_abund = [cfg.par.neb_abund,cfg.par.neb_abund,cfg.par.neb_abund]
+            cfg.par.neb_abund = [cfg.par.neb_abund,cfg.par.neb_abund,cfg.par.neb_abund,cfg.par.neb_abund]
     except:
-        cfg.par.neb_abund = ["dopita","dopita","dopita"]
+        cfg.par.neb_abund = ["dopita","dopita","dopita","dopita"]
     
     try:
         cfg.par.add_young_stars
@@ -415,4 +415,24 @@ def variable_set():
     except:
         cfg.par.explicit_pah = False
 
-    return cfg.par.FORCE_RANDOM_SEED, cfg.par.FORCE_BINNED, cfg.par.max_age_direct, cfg.par.imf1, cfg.par.imf2, cfg.par.imf3, cfg.par.use_cmdf, cfg.par.use_cloudy_tables, cfg.par.cmdf_min_mass, cfg.par.cmdf_max_mass, cfg.par.cmdf_bins, cfg.par.cmdf_beta, cfg.par.FORCE_gas_logu, cfg.par.gas_logu, cfg.par.gas_logu_init, cfg.par.FORCE_gas_logz, cfg.par.gas_logz, cfg.par.FORCE_logq, cfg.par.source_logq, cfg.par.FORCE_inner_radius, cfg.par.inner_radius, cfg.par.FORCE_N_O_Pilyugin, cfg.par.FORCE_N_O_ratio, cfg.par.N_O_ratio, cfg.par.neb_abund, cfg.par.add_young_stars, cfg.par.HII_Rinner_per_Rs, cfg.par.HII_nh, cfg.par.HII_min_age, cfg.par.HII_max_age, cfg.par.HII_escape_fraction, cfg.par.HII_alpha_enhance, cfg.par.add_pagb_stars, cfg.par.PAGB_min_age, cfg.par.PAGB_max_age, cfg.par.PAGB_N_enhancement, cfg.par.PAGB_C_enhancement, cfg.par.PAGB_Rinner_per_Rs, cfg.par.PAGB_nh, cfg.par.PAGB_escape_fraction, cfg.par.add_AGN_neb, cfg.par.AGN_nh, cfg.par.AGN_num_gas, cfg.par.dump_emlines, cfg.par.cloudy_cleanup, cfg.par.BH_SED, cfg.par.IMAGING, cfg.par.SED, cfg.par.IMAGING_TRANSMISSION_FILTER, cfg.par.SED_MONOCHROMATIC, cfg.par.SKIP_RT, cfg.par.FIX_SED_MONOCHROMATIC_WAVELENGTHS, cfg.par.n_MPI_processes, cfg.par.SOURCES_RANDOM_POSITIONS, cfg.par.SUBLIMATION, cfg.par.SUBLIMATION_TEMPERATURE, cfg.model.TCMB, cfg.model.THETA, cfg.model.PHI, cfg.par.MANUAL_ORIENTATION, cfg.par.solar, cfg.par.dust_grid_type, cfg.par.BH_model, cfg.par.BH_modelfile, cfg.par.BH_var, cfg.par.FORCE_STELLAR_AGES,cfg.par.FORCE_STELLAR_AGES_VALUE, cfg.par.FORCE_STELLAR_METALLICITIES, cfg.par.FORCE_STELLAR_METALLICITIES_VALUE, cfg.par.NEB_DEBUG, cfg.par.filterdir, cfg.par.filterfiles,  cfg.par.PAH_frac,cfg.par.otf_extinction,cfg.par.explicit_pah
+    try:
+        cfg.par.add_DIG_neb 
+    except:
+        cfg.par.add_DIG_neb = False
+
+    try:
+        cfg.par.DIG_nh
+    except:
+        cfg.par.DIG_nh = 1e1
+
+    try:
+        cfg.par.DIG_min_factor
+    except:
+        cfg.par.DIG_min_factor = 1
+
+    try:
+        cfg.par.DIFF_DIG_SED
+    except:
+        cfg.par.DIFF_DIG_SED = False
+
+    return cfg.par.FORCE_RANDOM_SEED, cfg.par.FORCE_BINNED, cfg.par.max_age_direct, cfg.par.imf1, cfg.par.imf2, cfg.par.imf3, cfg.par.use_cmdf, cfg.par.use_cloudy_tables, cfg.par.cmdf_min_mass, cfg.par.cmdf_max_mass, cfg.par.cmdf_bins, cfg.par.cmdf_beta, cfg.par.FORCE_gas_logu, cfg.par.gas_logu, cfg.par.gas_logu_init, cfg.par.FORCE_gas_logz, cfg.par.gas_logz, cfg.par.FORCE_logq, cfg.par.source_logq, cfg.par.FORCE_inner_radius, cfg.par.inner_radius, cfg.par.FORCE_N_O_Pilyugin, cfg.par.FORCE_N_O_ratio, cfg.par.N_O_ratio, cfg.par.neb_abund, cfg.par.add_young_stars, cfg.par.HII_Rinner_per_Rs, cfg.par.HII_nh, cfg.par.HII_min_age, cfg.par.HII_max_age, cfg.par.HII_escape_fraction, cfg.par.HII_alpha_enhance, cfg.par.add_pagb_stars, cfg.par.PAGB_min_age, cfg.par.PAGB_max_age, cfg.par.PAGB_N_enhancement, cfg.par.PAGB_C_enhancement, cfg.par.PAGB_Rinner_per_Rs, cfg.par.PAGB_nh, cfg.par.PAGB_escape_fraction, cfg.par.add_AGN_neb, cfg.par.AGN_nh, cfg.par.AGN_num_gas, cfg.par.dump_emlines, cfg.par.cloudy_cleanup, cfg.par.BH_SED, cfg.par.IMAGING, cfg.par.SED, cfg.par.IMAGING_TRANSMISSION_FILTER, cfg.par.SED_MONOCHROMATIC, cfg.par.SKIP_RT, cfg.par.FIX_SED_MONOCHROMATIC_WAVELENGTHS, cfg.par.n_MPI_processes, cfg.par.SOURCES_RANDOM_POSITIONS, cfg.par.SUBLIMATION, cfg.par.SUBLIMATION_TEMPERATURE, cfg.model.TCMB, cfg.model.THETA, cfg.model.PHI, cfg.par.MANUAL_ORIENTATION, cfg.par.solar, cfg.par.dust_grid_type, cfg.par.BH_model, cfg.par.BH_modelfile, cfg.par.BH_var, cfg.par.FORCE_STELLAR_AGES,cfg.par.FORCE_STELLAR_AGES_VALUE, cfg.par.FORCE_STELLAR_METALLICITIES, cfg.par.FORCE_STELLAR_METALLICITIES_VALUE, cfg.par.NEB_DEBUG, cfg.par.filterdir, cfg.par.filterfiles,  cfg.par.PAH_frac,cfg.par.otf_extinction, cfg.par.explicit_pah, cfg.par.add_DIG_neb, cfg.par.DIG_nh, cfg.par.DIG_min_factor, cfg.par.DIFF_DIG_SED

--- a/powderday/backwards_compatibility.py
+++ b/powderday/backwards_compatibility.py
@@ -124,7 +124,7 @@ def variable_set():
     try:
         if len(np.atleast_1d(cfg.par.FORCE_N_O_Pilyugin)) == 1:
             cfg.par.FORCE_N_O_Pilyugin = [cfg.par.FORCE_N_O_Pilyugin,cfg.par.FORCE_N_O_Pilyugin,cfg.par.FORCE_N_O_Pilyugin]
-        except:
+    except:
             cfg.par.FORCE_N_O_Pilyugin = [False, False, False]
     
     try:
@@ -164,7 +164,7 @@ def variable_set():
     except:
         cfg.par.HII_nh = 1.e2
 
-	try:
+    try:
         cfg.par.HII_min_age
     except:
         cfg.par.HII_min_age = 1.e-3

--- a/powderday/front_ends/gadget2pd.py
+++ b/powderday/front_ends/gadget2pd.py
@@ -102,7 +102,12 @@ def gadget_field_add(fname, bounding_box=None, ds=None,add_smoothed_quantities=T
         if  yt.__version__ == '4.0.dev0':
             return data.ds.parameters['octree'][('PartType0', 'metallicity')]
         else:
-            return data[("deposit","PartType0_smoothed_metallicity")]
+            el_str = field.name[1]
+            if '_' in el_str:
+                el_name = field.name[1][field.name[1].find('_')+1:]+"_"
+            else:
+                el_name = ""
+            return data[("deposit","PartType0_smoothed_"+el_name+"metallicity")]
 
     def _gassmoothedmasses(field, data):
         if  yt.__version__ == '4.0.dev0':
@@ -435,9 +440,21 @@ def gadget_field_add(fname, bounding_box=None, ds=None,add_smoothed_quantities=T
     ds.add_field(('gascoordinates'), function=_gascoordinates, sampling_type='particle',units='cm', particle_type=True)
     if add_smoothed_quantities == True:
         ds.add_field(('gassmootheddensity'), function=_gassmootheddensity, sampling_type='particle',units='g/cm**3', particle_type=True)
-        ds.add_field(('gassmoothedmetals'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
         ds.add_field(('gassmoothedmasses'), function=_gassmoothedmasses, sampling_type='particle',units='g', particle_type=True)
-
+        #try:
+        ds.add_field(('gassmoothedmetals'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_He'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_C'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_N'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_O'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_Ne'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_Mg'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_Si'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_S'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_Ca'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        ds.add_field(('gassmoothedmetals_Fe'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
+        #except:
+        #    ds.add_field(('gassmoothedmetals'), function=_gassmoothedmetals, sampling_type='particle',units='code_metallicity', particle_type=True)
 
     if cfg.par.BH_SED == True:
         if ('PartType5','BH_Mass') in ds.derived_field_list:

--- a/powderday/nebular_emission/ASCIItools.py
+++ b/powderday/nebular_emission/ASCIItools.py
@@ -24,7 +24,9 @@ retrieved in October 2019)
 --------------------------------------------------------------------------------------
 """
 
-if (cfg.par.add_neb_emission) and (not cfg.par.use_cloudy_tables):
+
+if (cfg.par.add_neb_emission) and (not cfg.par.use_cloudy_tables or cfg.par.add_pagb_stars or cfg.par.add_AGN_neb or cfg.par.add_DIG_neb):
+
     try:
         CLOUDY_EXE = os.environ['CLOUDY_EXE']
     except KeyError:
@@ -36,7 +38,6 @@ if (cfg.par.add_neb_emission) and (not cfg.par.use_cloudy_tables):
     except KeyError:
         print('Cloudy data path not set. Assuming standard cloudy structure')
         CLOUDY_DATA_PATH = '/'.join(CLOUDY_EXE.split('/')[:-2])+'/data'
-
 
 class WriteASCII(object):
     """

--- a/powderday/nebular_emission/cloudy_model.py
+++ b/powderday/nebular_emission/cloudy_model.py
@@ -130,7 +130,7 @@ def write_cloudy_input(**kwargs):
         if cfg.par.FORCE_N_O_Pilyugin[_id]: # Adding N/O pilyugin relation
             if 12 + abund_metal[3] < 8.14:
                 abund_metal[2] = -1.493 + abund_metal[3]
-           else:
+            else:
                 abund_metal[2] =  1.489*(12 + abund_metal[3]) - 13.613 + abund_metal[3]
        
         if cfg.par.FORCE_N_O_ratio[_id]:

--- a/powderday/nebular_emission/cloudy_model.py
+++ b/powderday/nebular_emission/cloudy_model.py
@@ -159,7 +159,7 @@ def write_cloudy_input(**kwargs):
         abund_N = float(abunds.elem_strs[2].split(" ")[3])
         abund_O = float(abunds.elem_strs[3].split(" ")[3])
         
-        if cfg.par.FORCE_N_O_Pilyugin[_id]: # Adding N/O pilyugin relation
+        if cfg.par.FORCE_N_O_Pilyugin[_id]: # Forcing the Nitrogen abundances to follow the N/O relation from Pilyugin et al. 2012
             if 12 + abund_N < 8.14:
                 abund_N = -1.493 + abund_O
             else:

--- a/powderday/nebular_emission/cloudy_tools.py
+++ b/powderday/nebular_emission/cloudy_tools.py
@@ -130,13 +130,14 @@ def convert_metals(metals):
     Converts metalicity from units of percentage by mass (SIMBA) 
     to atom per hydrogen atoms (CLOUDY)
     """
+    per_H = 0.7381 # Photospheric mass fraction from Asplund et al. 2009
     # mass of elements in unified atomic mass units
     # [He, C, N, O, Ne, Mg, Si, S, Ca, Fe]
-    per_H = 0.7314
     mass_H = 1.008
-    mass = [4.002602, 12.001, 14.007, 15.999, 20.1797, 
+    mass = [4.002602, 12.001, 14.007, 15.999, 20.1797,
             24.305, 28.085, 32.06, 40.078, 55.845]
     metals_conv = np.zeros(len(metals))
+    # Converting from mass fraction to atomic fraction
     for i in range(len(metals)):
         metals_conv[i] = np.log10((metals[i]/per_H)*(mass_H/mass[i]))
 

--- a/powderday/source_creation.py
+++ b/powderday/source_creation.py
@@ -446,7 +446,7 @@ def BH_source_add(m,reg,df_nu,boost):
 
         print ('Number AGNs in the cutout with non zero luminositites: ', len(agn_ids))
 
-        fnu_arr = sg.get_agn_seds(agn_ids)
+        fnu_arr = sg.get_agn_seds(agn_ids, reg)
         nu = reg["bhnu"].value
 
         for j in range(len(agn_ids)):

--- a/powderday/sph_tributary.py
+++ b/powderday/sph_tributary.py
@@ -96,7 +96,7 @@ def sph_m_gen(fname,field_add):
 
     pto.test_octree(refined,max_level)
 
-    dump_cell_info(refined,fc1,fw1,xmin,xmax,ymin,ymax,zmin,zmax)
+    dump_cell_info(refined,fc1.convert_to_units('cm'),fw1.convert_to_units('cm'),xmin,xmax,ymin,ymax,zmin,zmax)
     np.save('refined.npy',refined)
     np.save('density.npy',dustdens)
     

--- a/tests/SKIRT/arepo_cluster/parameters_master_arepo.py
+++ b/tests/SKIRT/arepo_cluster/parameters_master_arepo.py
@@ -128,6 +128,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: 1.e19, Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default: False)
 
@@ -168,12 +171,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 #****************
 # Post-AGB STARS

--- a/tests/SKIRT/arepo_cluster/parameters_master_arepo.py
+++ b/tests/SKIRT/arepo_cluster/parameters_master_arepo.py
@@ -128,32 +128,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: 1.e19, Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
-                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+FORCE_N_O_Pilyugin = [False, False, False, False]   # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                                    # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default: False)
+FORCE_N_O_ratio = [False, False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter).
+                            			           # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			           # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: True)
-
-neb_abund = ["direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
+neb_abund = ["direct", "direct", "direct", "direct"]    # This sets the HII region elemental abundances for generating CLOUDY models.
+                            			                # Available abundaces are.
+                                                        #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                                                        #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                                                        #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                                                        #               new depletion and factors in ISM grains.
+                                                        #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998)
+                                                        #               and Caffau+2011
+                                                        #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is
+                                                        #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                                                        #               Make sure to set FORCE_BINNED to False)
+                                                        # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -162,26 +157,26 @@ neb_abund = ["direct", "direct", "direct"]  # This sets the HII region elemental
 add_young_stars = True      			    # If set, the young stars are included when calculating nebular emission (Default: False)
 
 
-HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to this value times the Stromgen Radius. 
-                            			    # For example, if set to 0.01 Rinner is taken to be 1 % of Stromgren Radius. 
+HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to this value times the Stromgen Radius.
+                            			    # For example, if set to 0.01 Rinner is taken to be 1 % of Stromgren Radius.
                             		    	# If FORCE_inner_radius (next parameter) is set to True then this is overridden
-                            			    # and the value set by the inner_radius is used. This parameter is used 
+                            			    # and the value set by the inner_radius is used. This parameter is used
                             			    # only when add_neb_emission = True and use_cloudy_tables = False (Default: 0.01)
-   
-HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
+
+HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3.
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
-HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr.
                                             # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
 
-HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
+HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr.
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
-HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
+HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region.
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
-HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
-                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals.
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the
                                             # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 #****************
@@ -190,19 +185,19 @@ HII_alpha_enhacement = False                # If set to True then the metallicit
 
 add_pagb_stars = False      			    # If set, the Post-AGB stars are included when calculating nebular emission (Default: False)
 
-PAGB_N_enhancement = 0.4    			    # Enhances the Nitrogen abundance Post-AGB stars by increasing the log(N/O) by this value. 
-                            			    # This used only when add_neb_emission = True, use_cloudy_tables = False and add_pagb_stars = True (Default = 0.4)  
+PAGB_N_enhancement = 0.4    			    # Enhances the Nitrogen abundance Post-AGB stars by increasing the log(N/O) by this value.
+                            			    # This used only when add_neb_emission = True, use_cloudy_tables = False and add_pagb_stars = True (Default = 0.4)
 
 PAGB_C_enhancement = 0.4    			    # Enhances the Carbon abundance Post-AGB stars by increasing the log(C/O) by this value.
                             			    # This used only when add_neb_emission = True, use_cloudy_tables = False and add_pagb_stars = True (Default = 0.4)
 
-PAGB_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to this value times the Stromgen Radius. 
-                            			    # For example, if set to 0.01 Rinner is taken to be 1 % of Stromgren Radius. 
+PAGB_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to this value times the Stromgen Radius.
+                            			    # For example, if set to 0.01 Rinner is taken to be 1 % of Stromgren Radius.
                             			    # If FORCE_inner_radius (next parameter) is set to True then this is overridden
-                            			    # and the value set by the inner_radius is used. This parameter is used 
+                            			    # and the value set by the inner_radius is used. This parameter is used
                             			    # only when add_neb_emission = True and use_cloudy_tables = False (Default: 0.01)
 
-PAGB_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
+PAGB_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3.
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
 PAGB_min_age = 0.1          		    	# Sets the minimum age limit for calculating nebular emission from post-AGB stars, in units of Gyr.
@@ -211,7 +206,7 @@ PAGB_min_age = 0.1          		    	# Sets the minimum age limit for calculating 
 PAGB_max_age = 10           			    # Sets the maximum age limit for calculating nebular emission from post-AGB stars, in units of Gyr.
                             			    # This is used only when add_neb_emission = True, use_cloudy_tables = False and add_pagb_stars = True (Default = 10)
 
-PAGB_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
+PAGB_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region.
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
 #**************
@@ -220,21 +215,39 @@ PAGB_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escap
 
 add_AGN_neb = False				            # If set, AGNs are included when calculating nebular emission (Default: False)
 
-AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
+AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emission in units if cm^-3.
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
-AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
+AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN.
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example,
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the
+                                            # Black (1987) SED (Default: 1).
+
+
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
 
-dump_emlines = False                        # If True, The emission lines are saved in a file before going through the dust radiative transfer. 
+dump_emlines = False                        # If True, The emission lines are saved in a file before going through the dust radiative transfer.
                                             # This can be used as a fast way getting emission lines for the purpose of debugging the code.
-                                            # Naming convention: emlines.galaxy*.txt where * is the galaxy number 
-                                            # This works only when add_neb_emission = True (Default: False) 
+                                            # Naming convention: emlines.galaxy*.txt where * is the galaxy number
+                                            # This works only when add_neb_emission = True (Default: False)
 
-cloudy_cleanup = True                       # If set to True, all the CLOUDY files will be deleted after the source addition is complete. 
+cloudy_cleanup = True                       # If set to True, all the CLOUDY files will be deleted after the source addition is complete.
                                             # Only relevant if add_neb_emission = True and use_cloudy_tables = False (Default: True)
 
 
@@ -386,4 +399,6 @@ FORCE_STELLAR_METALLICITIES_VALUE = 0.012 # absolute values (so 0.013 ~ solar)
 NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file for debugging.
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
-                  # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+                  # Naming convention: nebular_properti
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved sperately with "_DIG" appended to the rtout fileses_galaxy*.txt where * is the galaxy number
+

--- a/tests/SKIRT/arepo_cluster/parameters_model_arepo.py
+++ b/tests/SKIRT/arepo_cluster/parameters_model_arepo.py
@@ -3,6 +3,9 @@
 snapnum_str = '59'
 hydro_dir = '/blue/narayanan/desika.narayanan/yt_datasets/TNGHalo/'
 
+galaxy_num = 0
+galaxy_num_str = str(galaxy_num)
+
 snapshot_name = 'halo_59.hdf5'
 
 #where the files should go

--- a/tests/SKIRT/arepo_idealized_extinction/parameters_master_arepo.py
+++ b/tests/SKIRT/arepo_idealized_extinction/parameters_master_arepo.py
@@ -144,32 +144,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
-
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -240,6 +235,24 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+
+
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -404,3 +417,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
 OTF_EXTINCTION_MRN_FORCE = False
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/tests/SKIRT/arepo_idealized_extinction/parameters_master_arepo.py
+++ b/tests/SKIRT/arepo_idealized_extinction/parameters_master_arepo.py
@@ -144,6 +144,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
@@ -184,13 +187,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
-
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 #****************
 # Post-AGB STARS
 #****************

--- a/tests/SKIRT/arepo_smuggle_low_res/parameters_master_arepo.py
+++ b/tests/SKIRT/arepo_smuggle_low_res/parameters_master_arepo.py
@@ -128,33 +128,28 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
-
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
-
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
+                            			              
 #***************************
 # YOUNG STARS (HII regions)
 #***************************
@@ -224,6 +219,23 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+											
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+                                            
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -386,3 +398,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved sperately with "_DIG" appended to the rtout fileses_galaxy*.txt where * is the galaxy number

--- a/tests/SKIRT/arepo_smuggle_low_res/parameters_master_arepo.py
+++ b/tests/SKIRT/arepo_smuggle_low_res/parameters_master_arepo.py
@@ -128,6 +128,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
@@ -168,13 +171,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
-
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 #****************
 # Post-AGB STARS
 #****************

--- a/tests/SKIRT/arepo_smuggle_low_res/parameters_model_arepo.py
+++ b/tests/SKIRT/arepo_smuggle_low_res/parameters_model_arepo.py
@@ -3,6 +3,9 @@
 snapnum_str = '143'
 hydro_dir = '/ufrc/narayanan/desika.narayanan/powderday_files/smuggle/low_res/'
 
+galaxy_num = 0
+galaxy_num_str = str(galaxy_num)
+
 snapshot_name = 'smuggle_snapshot_143.low_res.hdf5'
 
 #where the files should go

--- a/tests/SKIRT/changa_mw/parameters_master_changa.py
+++ b/tests/SKIRT/changa_mw/parameters_master_changa.py
@@ -128,6 +128,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
@@ -168,12 +171,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 #****************
 # Post-AGB STARS

--- a/tests/SKIRT/changa_mw/parameters_master_changa.py
+++ b/tests/SKIRT/changa_mw/parameters_master_changa.py
@@ -128,32 +128,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
-
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -225,6 +220,23 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+											
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+                                            
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -388,3 +400,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/tests/SKIRT/changa_mw/parameters_model_changa.py
+++ b/tests/SKIRT/changa_mw/parameters_model_changa.py
@@ -2,6 +2,11 @@
 
 snapnum_str = '004096'
 hydro_dir = '/blue/narayanan/desika.narayanan/powderday_files/tremmel/starform_example/'
+galaxy_num = 0
+
+
+galaxy_num_str = str(galaxy_num)
+snapnum_str = '{:03d}'.format(snapshot_num)
 
 snapshot_name = 'pioneer50h243.1536gst1bwK1BH.004096'
 

--- a/tests/SKIRT/enzo_disk/parameters_master_enzo.py
+++ b/tests/SKIRT/enzo_disk/parameters_master_enzo.py
@@ -125,35 +125,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
     										# For AGN we keep the inner radius fixed at whatever is set by inner_radius (next parameter) 
     										# irrespective of what this parameter is set to. (Default: [False,False,True])
 
-inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
-                                            # use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
-
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
-
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -224,6 +216,23 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -387,3 +396,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/tests/SKIRT/enzo_disk/parameters_master_enzo.py
+++ b/tests/SKIRT/enzo_disk/parameters_master_enzo.py
@@ -126,7 +126,10 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
     										# irrespective of what this parameter is set to. (Default: [False,False,True])
 
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
-                            		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
+                                            # use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
+
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
@@ -168,13 +171,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
-
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 #****************
 # Post-AGB STARS
 #****************

--- a/tests/SKIRT/enzo_disk/parameters_model_enzo.py
+++ b/tests/SKIRT/enzo_disk/parameters_model_enzo.py
@@ -5,6 +5,9 @@ snapnum_str = '{:03d}'.format(snapshot_num)
 
 hydro_dir = '/ufrc/narayanan/desika.narayanan/yt_datasets/enzo_iso_galaxy/galaxy0030/'
 
+galaxy_num = 0
+galaxy_num_str = str(galaxy_num)
+
 snapshot_name = 'galaxy0030'
 
 #where the files should go

--- a/tests/SKIRT/gasoline_disk/parameters_master_gasoline.py
+++ b/tests/SKIRT/gasoline_disk/parameters_master_gasoline.py
@@ -128,6 +128,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
@@ -158,7 +161,6 @@ neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental
 
 add_young_stars = True      			    # If set, the young stars are included when calculating nebular emission (Default: False)
 
-
 HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to this value times the Stromgen Radius. 
                             			    # For example, if set to 0.01 Rinner is taken to be 1 % of Stromgren Radius. 
                             		    	# If FORCE_inner_radius (next parameter) is set to True then this is overridden
@@ -168,12 +170,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 #****************
 # Post-AGB STARS

--- a/tests/SKIRT/gasoline_disk/parameters_master_gasoline.py
+++ b/tests/SKIRT/gasoline_disk/parameters_master_gasoline.py
@@ -128,32 +128,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
-
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -224,6 +219,24 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+											
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+
+
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -387,3 +400,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/tests/SKIRT/gasoline_disk/parameters_model_gasoline.py
+++ b/tests/SKIRT/gasoline_disk/parameters_model_gasoline.py
@@ -3,6 +3,11 @@
 snapnum_str = '00300'
 hydro_dir = '/blue/narayanan/desika.narayanan/yt_datasets/TipsyGalaxy/'
 
+galaxy_num = 0
+
+
+galaxy_num_str = str(galaxy_num)
+
 snapshot_name = 'galaxy.00300'
 
 #where the files should go

--- a/tests/SKIRT/gizmo_fire/parameters_master_gizmo.py
+++ b/tests/SKIRT/gizmo_fire/parameters_master_gizmo.py
@@ -128,6 +128,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
@@ -168,12 +171,19 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
+                                                                                        
 
 #****************
 # Post-AGB STARS

--- a/tests/SKIRT/gizmo_fire/parameters_master_gizmo.py
+++ b/tests/SKIRT/gizmo_fire/parameters_master_gizmo.py
@@ -134,26 +134,27 @@ FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundance
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
+
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -225,7 +226,25 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
+			
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -389,3 +408,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/tests/SKIRT/gizmo_fire/parameters_model_gizmo.py
+++ b/tests/SKIRT/gizmo_fire/parameters_model_gizmo.py
@@ -5,6 +5,9 @@ snapnum_str = '{:03d}'.format(snapshot_num)
 
 hydro_dir = '/blue/narayanan/desika.narayanan/powderday_files/gizmo/fire1/FIRE_M12i_ref11/'
 
+galaxy_num = 0
+galaxy_num_str = str(galaxy_num)
+
 snapshot_name = 'snapshot_'+snapnum_str+'.hdf5'
 
 #where the files should go

--- a/tests/SKIRT/gizmo_mw_zoom/parameters_master_gizmo.py
+++ b/tests/SKIRT/gizmo_mw_zoom/parameters_master_gizmo.py
@@ -128,16 +128,14 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
 N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
                             			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
-
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
 
 neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
                             			    # Available abundaces are.
@@ -168,12 +166,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 #****************
 # Post-AGB STARS

--- a/tests/SKIRT/gizmo_mw_zoom/parameters_master_gizmo.py
+++ b/tests/SKIRT/gizmo_mw_zoom/parameters_master_gizmo.py
@@ -96,7 +96,8 @@ cmdf_beta = -2.0                            # Beta (power law exponent) for calc
 #**********************
 # COMMON PARAMETERS
 #***********************
-# NOTE: These parmeters take three values as an input. They correspond to the value of the pararmeter for young_stars, PAGB stars and AGN respectively.
+# NOTE: These parmeters take either three or four values as an input. 
+# They correspond to the value of the pararmeter for young_stars, PAGB stars, AGN and DIG respectively.
 
 FORCE_gas_logu = [False, False, False] 	    # If set, then we force the ionization parameter (gas_logu) to be 
                             			    # gas_logu (next parameter) else, it is taken to be variable and dependent on ionizing 
@@ -128,27 +129,27 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
-                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                                   # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			           # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			           # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
 
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
+neb_abund = ["dopita", "dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -220,6 +221,23 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+											
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 1                          # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+                                            
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -231,7 +249,6 @@ dump_emlines = False                        # If True, The emission lines are sa
 
 cloudy_cleanup = True                       # If set to True, all the CLOUDY files will be deleted after the source addition is complete. 
                                             # Only relevant if add_neb_emission = True and use_cloudy_tables = False (Default: True)
-
 
 #===============================================
 #BIRTH CLOUD INFORMATION
@@ -383,3 +400,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # The file includes the ionization parameter, number of ionizing photons, 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files

--- a/tests/SKIRT/gizmo_mw_zoom/parameters_model_gizmo.py
+++ b/tests/SKIRT/gizmo_mw_zoom/parameters_model_gizmo.py
@@ -3,6 +3,9 @@
 snapshot_num = 134
 snapnum_str = '{:03d}'.format(snapshot_num)
 
+galaxy_num = 0
+galaxy_num_str = str(galaxy_num)
+
 hydro_dir = '/blue/narayanan/desika.narayanan/powderday_files/gizmo/mufasa/'
 
 snapshot_name = 'snapshot_'+snapnum_str+'.hdf5'

--- a/tests/SKIRT/m12_extinction/parameters_master_gizmo.py
+++ b/tests/SKIRT/m12_extinction/parameters_master_gizmo.py
@@ -144,6 +144,9 @@ FORCE_inner_radius = [False, False, True]   # If set, then we force the inner ra
 inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
                             		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
 
+FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+                                            # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
+
 FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
                             			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
 
@@ -184,12 +187,18 @@ HII_Rinner_per_Rs = 0.01        		    # Rinner for cloudy calculations is set to
 HII_nh = 1.e2               			    # Gas hydrogen density for calcualting nebular emission in units if cm^-3. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e2)
 
+HII_min_age = 1.e-3                         # Sets the minimum age limit for calculating nebular emission in units of Gyr. 
+                                            # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-3)
+
 HII_max_age = 1.e-2         			    # Sets the maximum age limit for calculating nebular emission in units of Gyr. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 1.e-2)
 
 HII_escape_fraction = 0.0   			    # Fraction of H-ionizaing photons that escape the HII region. 
                             			    # This is used only when add_neb_emission = True and use_cloudy_tables = False (Default = 0.0)
 
+HII_alpha_enhacement = False                # If set to True then the metallicity of star particles to Fe/H rather than the total metals. 
+                                            # Since FSPS does not support non solar abundance ratios, this parameter can be used to mimic the 
+                                            # hardening of the radiaiton field due to alpha-enhancement. (Default: False)
 
 #****************
 # Post-AGB STARS

--- a/tests/SKIRT/m12_extinction/parameters_master_gizmo.py
+++ b/tests/SKIRT/m12_extinction/parameters_master_gizmo.py
@@ -130,46 +130,31 @@ FORCE_gas_logz = [False, False, False]      # If set, then we force the metallic
 gas_logz = [0.0, 0.0, 0.0]  			    # Metallicity of the HII region in units of log(Z/Z_sun)
                             			    # only relevant if add_neb_emission = True and FORCE_gas_logz = True (Default: [0.0, 0.0, 0.0])
 
-FORCE_logq = [False, False, False]      	# If set, then we force the number of ionizing photons to be source_logq (next parameter)
-                                            # else, it is taken to be variable and dependent on ionizing radiation of the source. (Default: [False, False, False])
+inner_radius = [1.e19, 1.e19, 2.777e+20]    # This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
+                            		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: 1.e19, Units = cm)
 
-source_logq = [1.e47, 1.e47,1.e47]          # The number of ionizing photons emitted by the source in units of s^-1. Only relevant if add_neb_emission = True, 
-    										# use_cloudy_tables = True and  FORCE_gas_logq = True (Default: [1.e47,1.e47,1.e47])  
-                                            
-FORCE_inner_radius = [False, False, True]   # If set, then we force the inner radius of the cloud to be inner_radius (next parameter). 
-											# IMP Note: This works only for young stars and Post-AGB stars. 
-    										# For AGN we keep the inner radius fixed at whatever is set by inner_radius (next parameter) 
-    										# irrespective of what this parameter is set to. (Default: [False,False,True])
-
-inner_radius = [1.e19, 1.e19, 2.777e+20]   	# This sets the inner radius of the cloud in cm. This is used only when add_neb_emission = True,
-                            		    	# use_cloudy_tables = False and FORCE_inner_radius = True (Default: [1.e19, 1.e19, 2.777e+20], Units = cm)
-
-FORCE_N_O_Pilyugin = [False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
+FORCE_N_O_Pilyugin = [False, False, False, False]  # If set to True, Nitrogen abundances are set according to the N/O vs O/H relation from Pilyugin et al. 2012
                                             # If FORCE_N_O ratio (next parameter) is set to True then this parameter is ignored.(Default: [False,False,False])
 
-FORCE_N_O_ratio = [False, False, False]     # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
-                            			    # This can be used as a template fix adundance ratio of other elements (Default:  [False, False, False])
+FORCE_N_O_ratio = [False, False, False, False]  # If set, then we force the log of N/O ratio to be N_O_ratio (next parameter). 
+                            			        # This can be used as a template fix adundance ratio of other elements (Default: False)
 
-N_O_ratio = [-0.85, -0.85, -0.85]           # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
-                            			    # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = [-0.85, -0.85, -0.85])
+N_O_ratio = [-0.85, -0.85, -0.85, -0.85]        # This sets the log of N/O ratio. This is used only when add_neb_emission = True,
+                            			        # use_cloudy_tables = False, FORCE_N/O ratio = True and neb_abund = "direct" (Default: = -0.85)
 
-use_Q = [True, True, True]                	# If True, we run CLOUDY by specifying number of ionizing photons which are calculated 
-                            			    # based on the input sed and the inner radius which is set to the Strömgren radius. 
-                            			    # else, CLOUDY is run by specifying just the ionization parameter.Only relevant if 
-                            			    # add_neb_emission = True and use_cloudy_tables = False (Default: [True, True, True])
+neb_abund = ["direct", "direct", "direct", "direct"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
+                            			              # Available abundaces are.
+                            			              #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
+                            			              #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
+                            			              #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
+                            			              #               new depletion and factors in ISM grains.
+                            			              #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
+                            			              #               and Caffau+2011 
+                            			              #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
+                            			              #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
+                            			              #               Make sure to set FORCE_BINNED to False)
+                            			              # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: dopita)
 
-neb_abund = ["dopita", "dopita", "dopita"]  # This sets the HII region elemental abundances for generating CLOUDY models. 
-                            			    # Available abundaces are.
-                            			    #    dopita:    Abundabces from Dopita (2001) with old solar abundances = 0.019 and ISM grains.
-                            			    #    newdopita: Abundances from Dopita (2013). Solar Abundances from Grevasse 2010 - z= 0.013
-                            			    #               includes smooth polynomial for N/O, C/O relationship functional form for He(z),
-                            			    #               new depletion and factors in ISM grains.
-                            			    #    gutkin:    Abundabces from Gutkin (2016) and PARSEC metallicity (Bressan+2012) based on Grevesse+Sauvel (1998) 
-                            			    #               and Caffau+2011 
-                            			    #    direct:    Abundances are taken directly from the simulation if possible. Defaults to using "dopita" if there is 
-                            			    #               an error. (Note: Works only for AGNs and star particles that are added directly without binning.
-                            			    #               Make sure to set FORCE_BINNED to False)
-                            			    # This is used only when add_neb_emission = True and use_cloudy_tables = False. (Default: ["dopita", "dopita", "dopita"])
 
 #***************************
 # YOUNG STARS (HII regions)
@@ -241,6 +226,23 @@ AGN_nh = 1.e3					            # Gas hydrogen density for calcualting nebular emi
 
 AGN_num_gas = 32							# For CLOUDY calculations we use the distance weighted average metallicity of gas particles around the AGN. 
 											# The number of gas particles used for doing so is set by this parameter. (Default: 32)
+
+#**********************
+# DIffused Ionized Gas (DIG)
+#**********************
+
+add_DIG_neb = False                         # If set, Contribution from DIG is included when calculating nebular emission (Default: False)
+
+DIG_nh = 1.e1                               # Gas hydrogen density for calcualting nebular emission in units of cm^-3. (Default: 10)
+
+DIG_min_factor = 3500                        # For DIG CLOUDY calculations we use Black (1987) SED as a template. The normalization of the SED is 
+                                            # set by a parameter called  "Factor". It is the ratio of total energy dumped in a cell to the total 
+                                            # energy of the Black (1987) SED, which we use as the template for setting the SED shape for calculating 
+                                            # DIG emission. This parameter sets the minimum factor that the code uses for calculation. For example, 
+                                            # setting this parameter to 1 causes the code to ignore all the cells that have a factor < 1 or in other 
+                                            # words ignore all the cells where the total energy dumped is less than the integrated energy of the 
+                                            # Black (1987) SED (Default: 1).
+                                            
 #*************************
 # DEBUGGING AND CLEAN UP
 #*************************
@@ -405,3 +407,4 @@ NEB_DEBUG = False # Dumps parameters related to nebular line emission in a file 
                   # metallicity, inner radius, stellar mass and age for each particle.
                   # Naming convention: nebular_properties_galaxy*.txt where * is the galaxy number
 OTF_EXTINCTION_MRN_FORCE = False
+DIFF_DIG_SED = False # If set, SEDs with DIG nebular emission are saved separately with "_DIG" appended to the rtout files


### PR DESCRIPTION
Update log:

- Nebular emission from DIG can now be added (Still under active development)
- New parameters added:
1. **add_DIG_neb**: Flag to turn on/off nebular emission from DIG.
2. **DIG_nh**:   Gas hydrogen density for calculating DIG nebular emission in units of cm^-3.
3. **DIG_min_factor**: Sets the minimum energy dumped that has to be included for DIG calculations

- **Dump cell info now saves cell widths and cell centers in centimeters instead of code units**                
