### PR TITLE
fix Astropy v4.3 compatibility issue (`Blackbody`)

### DIFF
--- a/powderday/helpers.py
+++ b/powderday/helpers.py
@@ -1,7 +1,8 @@
 import numpy as np
 import powderday.config as cfg
 from astropy import units as u
-from astropy.modeling.blackbody import blackbody_lambda,blackbody_nu
+# from astropy.modeling.blackbody import blackbody_lambda,blackbody_nu
+from astropy.modeling.models import BlackBody
 import h5py
 
 def find_nearest(array,value):
@@ -18,8 +19,11 @@ def get_J_CMB():
 
     wavelengths = np.linspace(min_lam,max_lam,1.e5)
 
-    
-    flux = blackbody_lambda(wavelengths,cfg.model.TCMB)
+    # flux = blackbody_lambda(wavelengths,cfg.model.TCMB) # blackbody_lambda deprecated in astropy v4.3
+    ## equivalent function provided here https://docs.astropy.org/en/v4.1/modeling/blackbody_deprecated.html#blackbody-functions-deprecated
+    bb_lam = BlackBody(cfg.model.TCMB * u.K, scale=1.0 * u.erg / (u.cm ** 2 * u.AA * u.s * u.sr))
+    flux = bb_lam(wavelengths)
+
     J = np.trapz(flux,wavelengths).to(u.erg/u.s/u.cm**2/u.sr)
     solid_angle = 4.*np.pi*u.sr
     J = J*solid_angle
@@ -35,8 +39,12 @@ def energy_density_absorbed_by_CMB():
     mw_o = mw_df['optical_properties']
     mw_df_nu = mw_o['nu']*u.Hz
     mw_df_chi = mw_o['chi']*u.cm**2/u.g
-    
-    b_nu = blackbody_nu(mw_df_nu,cfg.model.TCMB)
+ 
+
+    # b_nu = blackbody_nu(mw_df_nu,cfg.model.TCMB) # blackbody_nu deprecated in astropy v4.3
+    ## equivalent function provided here https://docs.astropy.org/en/v4.1/modeling/blackbody_deprecated.html#blackbody-functions-deprecated
+    bb_nu = BlackBody(cfg.model.TCMB * u.K)
+    b_nu = bb_nu(mw_df_nu)
     
     #energy_density_absorbed = 4pi int b_nu * kappa_nu d_nu since b_nu
     #has units erg/s/cm^2/Hz/str and kappa_nu has units cm^2/g.  this results in units erg/s/g


### PR DESCRIPTION
`blackbody_lambda` and `blackbody_nu` deprecated in astropy v4.3 for more general `Blackbody` model. Equivalent functionality, implemented in this PR, detailed [here](https://docs.astropy.org/en/v4.1/modeling/blackbody_deprecated.html#blackbody-functions-deprecated)