### PR TITLE
Critical Bug Fix: scaling FSPS spectra by correct stellar mass

### DIFF
--- a/powderday/SED_gen.py
+++ b/powderday/SED_gen.py
@@ -267,9 +267,11 @@ def allstars_sed_gen(stars_list,cosmoflag,sp):
     
     stellar_fnu = np.zeros([nstars,nlam])
     mfrac = np.zeros(nstars)
+    # see newstars_gen() for info on mfrac
     star_counter=0
     for i in range(nchunks):
         fnu_list = chunk_sol[i][0] #this is a list of the stellar_fnu's returned by that chunk
+        #chunk_sol now returns two things for each star/star bin: the spectrum and the associated surviving stellar mass fraction for that SSP 
         mfrac_list = chunk_sol[i][1]
         for j in range(len(fnu_list)):
             mfrac[star_counter] = mfrac_list[j] 
@@ -422,7 +424,11 @@ def newstars_gen(stars_list):
 
         spec_noneb = sp.get_spectrum(tage=stars_list[i].age,zmet=stars_list[i].fsps_zmet)
         f = spec_noneb[1]
-        #for later mass normalization of spectrum
+        #NOTE: FSPS SSP/CSP spectra are scaled by *formed* mass, not current mass. i.e., the SFHs of the SSP/CSP are normalized such that 1 solar mass
+        #is formed over the history. This means that the stellar spectra are normalized by the integral of the SFH =/= current 
+        #(surviving, observed, etc.) stellar mass. In simulations, we only know the current star particle mass. To get the formed mass for an SSP,
+        #we generate the surviving mass fraction (sp.stellar_mass) to extrapolate the initial mass from the current mass, metallicity, and age
+        #this 'mfrac' is used to scale the FSPS SSP luminosities in source_creation
         mfrac[i] = sp.stellar_mass
 
         pagb = cfg.par.add_pagb_stars and cfg.par.PAGB_min_age <= stars_list[i].age <= cfg.par.PAGB_max_age

--- a/powderday/source_creation.py
+++ b/powderday/source_creation.py
@@ -43,7 +43,7 @@ def direct_add_stars(df_nu, stars_list, diskstars_list, bulgestars_list, cosmofl
         print ("Number of unbinned stars to added: ", nstars)
     
     stellar_nu, stellar_fnu, disk_fnu, bulge_fnu, mfrac = sg.allstars_sed_gen(unbinned_stars_list, cosmoflag, sp)
-
+    #SED_gen now returns an additional parameter, mfrac, to properly scale the FSPS SSP spectra, which are in units of formed mass, not current stellar mass
     for i in range(nstars):
         nu = stellar_nu[:]
         fnu = stellar_fnu[i, :]
@@ -333,6 +333,9 @@ def add_binned_seds(df_nu,stars_list,diskstars_list,bulgestars_list,cosmoflag,m,
 
                     
                     #source luminosities
+                    #here, each (wz, wa, wm) bin will have an associated mfrac that corresponds to the fnu generated for this bin
+                    #while each star particle in the bin has a distinct mass, they all share mfrac as this value depends only on the age and Z of the star
+                    #thus, there are 'counter' number of binned_mfrac values (to match the number of fnu arrays)
                     lum = np.array([stars_list[i].mass/constants.M_sun.cgs.value*constants.L_sun.cgs.value/binned_mfrac[counter] for i in stars_in_bin[(wz,wa,wm)]])
                     lum *= np.absolute(np.trapz(fnu,x=nu))
                     source.luminosity = lum


### PR DESCRIPTION
SED_gen and source_creation have been modified to scale star particle SSP luminosities by formed mass (= integral of SFH) rather than current mass. 

Reason: FSPS SFHs are normalized such that 1 solar mass is formed over the entire history, resulting in SSP/CSP spectra that are in units of Lsun/Hz/Mformed, where Mformed is the integral of the SFH. For single age SSPs, this is equal to the initial formed mass, which for older populations is different than the current mass due to mass loss of evolved stars. To scale by the formed mass, SED_gen now returns an additional parameter 'mfrac' which is the surviving stellar mass fraction for each SSP (Mformed = current mass / mfrac). SSP luminosities are then scaled by current_mass/mfrac to correctly account for the FSPS units scaling. 