### PR TITLE
ionizing photon rate (Q) is now calculated using formed mass 

### DIFF
--- a/powderday/SED_gen.py
+++ b/powderday/SED_gen.py
@@ -506,9 +506,11 @@ def newstars_gen(stars_list):
                             sp1.params["dust_tesc"] = tesc_age
 
                         spec = sp1.get_spectrum(tage=stars_list[i].age)
+                        mfrac_neb = sp1.stellar_mass
 
                     else:
                         spec = sp.get_spectrum(tage=stars_list[i].age,zmet=stars_list[i].fsps_zmet)
+                        mfrac_neb = sp.stellar_mass
 
                     alpha = 2.5e-13 # Recombination Rate (assuming T = 10^4 K)
 
@@ -524,7 +526,7 @@ def newstars_gen(stars_list):
 
                     else:
                         LogQ = calc_LogQ(1.e8*constants.c.cgs.value/spec[0], spec[1]*constants.L_sun.cgs.value
-                                , efrac=escape_fraction, mstar=10**cluster_mass[j])   
+                                , efrac=escape_fraction, mstar=10**cluster_mass[j], mfrac=mfrac_neb)   
                         Rs = ((3*(10 ** LogQ))/(4*np.pi*(nh**2)*alpha))**(1./3.)
                         LogU = np.log10((10**LogQ)/(4*np.pi*Rs*Rs*nh*constants.c.cgs.value))+cfg.par.gas_logu_init[id_val]
                         LogQ = np.log10((10 ** (3*LogU))*(36*np.pi*(constants.c.cgs.value**3))/((alpha**2)*nh))

--- a/powderday/nebular_emission/cloudy_tools.py
+++ b/powderday/nebular_emission/cloudy_tools.py
@@ -12,7 +12,7 @@ From cloudyfsps written by Nell Byler.
 """
 
 
-def calc_LogQ(nuin0, specin0, efrac=0.0, mstar=1.0):
+def calc_LogQ(nuin0, specin0, efrac=0.0, mstar=1.0, mfrac=1.0):
     '''
     Claculates the number of lyman ionizing photons (Q) for given a spectrum
     Q = int(Lnu/hnu dnu, nu_0, inf)
@@ -35,7 +35,7 @@ def calc_LogQ(nuin0, specin0, efrac=0.0, mstar=1.0):
     nu = hlam[::-1]
     f_nu = hflu[::-1]
     integrand = f_nu / (h * nu)
-    logQ = np.log10(integrate.simps(integrand, x=nu)*mstar*(1-efrac))
+    logQ = np.log10(integrate.simps(integrand, x=nu)*(mstar/mfrac)*(1-efrac))
     return logQ
 
    


### PR DESCRIPTION
FSPS normalizes the SED by the formed (initial) mass of the star particle and not the current mass. To take this into account changes were introduced in commit #150. 

These changes are now added to nebular emission calculation as well. Specifically, the rate of ionizing photons (Q) is now calculated using the initial mass and not the current mass.