### PR TITLE
Updates tipsy frontend for yt.4, li_ml dust grid option

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -125,7 +125,7 @@ The second and manual way to install `Hyperion
 #. Make sure that you have the correct modules loaded on your cluster.
    This will require a compiler, openmpi and HDF5.  For example, on
    the University of Florida HiPerGator supercomputing system, I would
-   have:
+   have::
 
    >module load intel/2018.1.163 openmpi/4.0.3 hdf5/1.10.1
      
@@ -363,3 +363,113 @@ your openmpi module that you previously had loaded for the `Hyperion
    >LDSHARED="icc -shared" CC=icc pip install -e .
 
 
+System Specific Installation Notes
+============
+
+HiPerGator at the University of Florida
+--------------
+
+[1] The first set of instructions for the University of Florida
+HiPerGator3.0 facility is to employ intel compilers, and to compile
+everything manually.  This allows the greatest flexibility, as well as
+the ability to use private forks of individual codes.
+
+First, load up the compilers that we'll use throughout::
+
+  >module load intel/2018.1.163
+  >module load openmpi/4.0.3
+  >module load hdf5/1.10.1
+  >module load git
+
+yt::
+
+  >cd $HOME
+  >git clone https://github.com/yt-project/yt
+  >cd yt
+  >pip install -e .
+
+
+fsps::
+
+  >cd $HOME
+  >git clone https://github.con/cconroy20/fsps
+
+in the Makefile set F90=$(FC) and this will ensure that the compilers
+`fsps <https://code.google.com/p/fsps/source/checkout>`_ uses are what
+you have module loaded.::
+  
+  >make clean
+  >make
+
+then in your .bashrc set the analog to::
+  
+  >export SPS_HOME=/Users/desika/fsps
+
+
+python fsps::
+
+  >cd $HOME
+  >git clone --recursive https://github.com/dfm/python-fsps.git
+  >cd python-fsps
+  >CC=icc F90=ifort python setup.py install
+
+
+hyperion::
+
+  >cd $HOME
+  >git clone https://github.com/hyperion-rt/hyperion.git
+  >cd hyperion
+  >python setup.py install
+  >git submodule init
+  >git submodule update
+  >./configure --prefix=$HOME/local
+  >make
+  >make install
+
+hyperion dust::
+
+  >cd $HOME
+  >wget http://pypi.python.org/packages/source/h/hyperion-dust/hyperion-dust-0.1.0.tar.gz
+  >tar -xzvf hyperion-dust-0.1.0.tar.gz
+  >cd hyperion-dust-0.1.0
+  >python setup.py build_dust
+  
+powderday::
+
+  >git clone https://github.com/dnarayanan/powderday.git
+  >cd powderday
+  >python setup.py install
+
+
+[2] The second set of instructions use gcc, and the conda installation
+of `Hyperion <http://www.hyperion-rt.org>`_.  Thanks to Paul Torrey
+for these.::
+
+  >module load openmpi/4.1.1 libz/1.2.11 hdf5/1.10.1 conda/4.12.0 git/2.30.1 gcc
+  >conda install -c conda-forge hyperion
+  >python -c "import hyperion" (just to ensure no errors thrown)
+  >hyperion (just to ensure command is found)
+  >python -m pip install fsps
+  >[set $SPS_HOME variable in .bashrc)
+  >cd $HOME
+  >git clone https://github.com/dnarayanan/powderday.git
+  >cd powderday
+  >python setup.py install
+
+then fix import six line in the equivalent of all of these::
+
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/model/model.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/util/validator.py 
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/conf/conf_files.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/filter/filter.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/dust/dust_type.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/model/model_output.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/densities/flared_disk.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/densities/alpha_disk.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/densities/bipolar_cavity.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/densities/ulrich_envelope.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/densities/power_law_envelope.py 
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/densities/ambient_medium.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/model/sed.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/model/image.py
+  >vi /home/paul.torrey/.conda/envs/pd_gcc/lib/python3.8/site-packages/hyperion/grid/yt3_wrappers.py

--- a/pd_front_end.py
+++ b/pd_front_end.py
@@ -67,22 +67,10 @@ cfg.par.FORCE_RANDOM_SEED, cfg.par.FORCE_BINNED, cfg.par.max_age_direct, cfg.par
 fname = cfg.model.hydro_dir+cfg.model.snapshot_name
 field_add, ds = stream(fname)
 
-# figure out which tributary we're going to
-
-ds_type = ds.dataset_type
-# define the options dictionary
-options = {'gadget_hdf5': m_control_sph,
-           'tipsy': m_control_sph,
-           'enzo_packed_3d': m_control_enzo,
-           'arepo_hdf5': m_control_arepo}
-
-m_gen = options[ds_type]()
-m, xcent, ycent, zcent, dx, dy, dz, reg, ds, boost = m_gen(fname, field_add)
-
 sp = fsps.StellarPopulation()
 
 #setting solar metallicity value based on isochrone
-#values assigned to cfg.par.solar taken from fsps/src/sps_vars 
+#values assigned to cfg.par.solar taken from fsps/src/sps_vars
 isochrone = str(sp.libraries[0])
 
 print(f'\n----------------------------------------------\nSetting solar metallicity value')
@@ -111,6 +99,18 @@ elif 'bpss' in isochrone:
     cfg.par.solar = 0.020
     print(f'solar metallicity = {cfg.par.solar}')
 print('----------------------------------------------')
+
+# figure out which tributary we're going to
+
+ds_type = ds.dataset_type
+# define the options dictionary
+options = {'gadget_hdf5': m_control_sph,
+           'tipsy': m_control_sph,
+           'enzo_packed_3d': m_control_enzo,
+           'arepo_hdf5': m_control_arepo}
+
+m_gen = options[ds_type]()
+m, xcent, ycent, zcent, dx, dy, dz, reg, ds, boost = m_gen(fname, field_add)
 
 # Get dust wavelengths. This needs to preceed the generation of sources
 # for hyperion since the wavelengths of the SEDs need to fit in the
@@ -178,7 +178,6 @@ if par.SOURCES_IN_CENTER == True:
         bulgestars_list[i].positions[:] =  np.array([xcent,ycent,zcent])
     for i in range(nstars_disk):
         diskstars_list[i].positions[:] = np.array([xcent,ycent,zcent])
-
 if par.SOURCES_RANDOM_POSITIONS == True:
     print "================================"
     print "SETTING SOURCES TO RANDOM POSITIONS"
@@ -237,4 +236,3 @@ if cfg.par.add_neb_emission and cfg.par.add_DIG_neb:
 
 if cfg.par.IMAGING:
     make_image(m_imaging, par, model, dx, dy, dz)
-

--- a/powderday/front_ends/tipsy2pd.py
+++ b/powderday/front_ends/tipsy2pd.py
@@ -4,72 +4,81 @@ import powderday.config as cfg
 from yt.config import ytcfg
 from yt.data_objects.particle_filters import add_particle_filter
 from powderday.mlt.dgr_extrarandomtree_part import dgr_ert
+from unyt import G
 
 #ytcfg["yt","skip_dataset_cache"] = "True"
 
 
 def tipsy_field_add(fname,bounding_box = None ,ds=None,add_smoothed_quantities=True):
 
+    def _gassmoothinglength(field,data):
+        return data[("Gas", "smoothing_length")].in_units('pc')
+
     def _starmetals(field,data):
-        return data[('newstars', 'Metals')]
+        return data[("newstars", "Metals")]
     
     def _starcoordinates(field,data):
-        return data[('newstars', 'Coordinates')]
+        return data[("newstars", "Coordinates")]
 
     def _starformationtime(field,data):
-        return data[('newstars', 'FormationTime')]
+        return data[("newstars", "FormationTime")]
 
     def _stellarages(field,data):
         ad = data.ds.all_data()
         simtime = data.ds.current_time.in_units('Gyr')
         simtime = simtime.value
-        age = simtime - ad["starformationtime"].in_units('Gyr').value
+        age = simtime - data[("newstars","FormationTime")].in_units('Gyr').value
         age[np.where(age < 1.e-3)[0]] = 1.e-3
         age = data.ds.arr(age,'Gyr')
         return age
 
     def _starmasses(field,data):
-        return data[('newstars', 'Mass')]
+        return data[("newstars", "Mass")]
 
 
     def _diskstarcoordinates(field,data):
-        return data[('diskstars','Coordinates')]
+        return data[("diskstars", "Coordinates")]
         
     def _diskstarmasses(field,data):
-        return data[("diskstars","Mass")]
+        return data[("diskstars", "Mass")]
     
     
     def _gasdensity(field,data):
-        return data[('Gas', 'Density')]
+        return data[("Gas", "Density")]
 
     def _gasmetals(field,data):
-        return data[('Gas', 'Metals')]
+        return data[("Gas", "Metals")]
         
     def _gascoordinates(field,data):
-        return data[('Gas','Coordinates')]
+        return data[("Gas", "Coordinates")]
 
     def _gassmootheddensity(field,data):
-        return data[('deposit', 'Gas_density')]
+        if float(yt.__version__[0:3]) >= 4:
+            return data.ds.parameters['octree'][("Gas", "Density")]
+        else:
+            return data[("deposit", "Gas_density")]
     
     def _gassmoothedmetals(field,data):
-        return data[('deposit', 'Gas_smoothed_metallicity')]
+        if float(yt.__version__[0:3]) >= 4:
+            return data.ds.parameters['octree'][("Gas", "Metals")]
+        else:
+            return data[("deposit", "Gas_smoothed_metallicity")]
+            # Does this field exist?
         
     def _gassmoothedmasses(field,data):
-        return data[('deposit', 'Gas_mass')]
+        if float(yt.__version__[0:3]) >= 4:
+            return data.ds.parameters['octree'][("Gas", "Mass")]
+        else:
+            return data[("deposit", "Gas_mass")]
 
     def _gasmasses(field,data):
-        return data[('Gas','Mass')]
+        return data[("Gas","Mass")]
 
     def _dustmass_dtm(field,data):
-        return (data["gasmasses"]*cfg.par.dusttometals_ratio)
+        return (data[("Gas","Metals")]*data[("Gas","Mass")]*cfg.par.dusttometals_ratio)
 
-
-    def _dustmass_li_ml(field,data):
-        li_ml_dgr = dgr_ert(data["gasmetals"],data["gassfr"],data["gasmasses"])
-        li_ml_dustmass = data.ds.arr(((10.**li_ml_dgr)*data["gasmasses"]),'code_mass')
-
-    
-        return li_ml_dustmass
+    def _li_ml_dustmass(field,data):
+        return (data.ds.arr(data.ds.parameters['li_ml_dustmass'].value,'code_mass'))
 
 
     def _dustmass_rr(field,data):
@@ -78,51 +87,71 @@ def tipsy_field_add(fname,bounding_box = None ,ds=None,add_smoothed_quantities=T
         alpha = 2.02
         x_sun = 8.69
 
-        x = 12.+np.log10(data["gasmetals"]/cfg.par.solar * 10.**(x_sun-12.) )
+        x = 12.+np.log10(data["Gas","Metals"]/cfg.par.solar * 10.**(x_sun-12.) )
         y = a + alpha*(x_sun-np.asarray(x))
         gas_to_dust_ratio = 10.**(y)
         dust_to_gas_ratio = 1./gas_to_dust_ratio
-        return dust_to_gas_ratio * data["gasmasses"]
+        return dust_to_gas_ratio * data["Gas","Mass"]
 
     def _dustmass_li_bestfit(field,data):
-        log_dust_to_gas_ratio = (2.445*np.log10(data["gasmetals"]/cfg.par.solar))-(2.029)
+        log_dust_to_gas_ratio = (2.445*np.log10(data["Gas","Metals"]/cfg.par.solar))-(2.029)
         dust_to_gas_ratio = 10.**(log_dust_to_gas_ratio)
-        return dust_to_gas_ratio * data["gasmasses"]
+        return dust_to_gas_ratio * data["Gas","Mass"]
 
 
     def _dustsmoothedmasses(field, data):
-        #if yt.__version__ == '4.0.dev0':
-        #    return (data.ds.parameters['octree'][('PartType0','Dust_Masses')])
+        if float(yt.__version__[0:3]) >= 4:
+            return (data.ds.parameters['octree'][("dust","mass")])
             
-        #else:
-        return (data.ds.arr(data[("deposit", "PartType0_sum_Dust_Masses")].value, 'code_mass'))
+        else:
+            return (data.ds.arr(data[("Gas", "dust_mass")].value, 'code_mass'))
 
 
     def _li_ml_dustsmoothedmasses(field,data):
-        #if yt.__version__ == '4.0.dev0':
-        #    return (data.ds.parameters['octree'][('PartType0', 'li_ml_dustmass')])
-        #else:
-        return (data.ds.arr(data[("deposit", "PartType0_sum_li_ml_dustmass")].value, 'code_mass'))
-
-
-
+        return (data.ds.parameters['octree'][("Gas", "li_ml_dustmass")])
 
 
     def _metaldens(field,data):
         return (data["Gas","Density"]*data["Gas","Metals"])
 
     def _gasfh2(field,data):
-        try: return data[('PartType0','FractionH2')] # change this
+        try: return data[("Gas","H2")]
         except: return (data.ds.arr(data[("Gas", "Mass")].value*0, 'dimensionless'))
 
     def _gassfr(field,data):
-        try: return data[('PartType0','StarFormationRate')] # change this
-        except: return (data.ds.arr(data[("Gas", "Mass")].value*0, 'code_mass/code_time'))
-
+        instsfr = data.ds.arr(data[("Gas", "Mass")].value*0, 'Msun/yr')
+        # temperature below which SF can happen (K)
+        try: tempcut = ds.quan(ds.parameters["dTempMax"],'K')
+        except: tempcut = ds.quan(10**3,'K') # default for g14 sims
+        denscut = ds.quan(100*1.67*10**-24,'g/cm**3') # density above which SF can happen - default for g14 sims
+        # star formation timescale (s)
+        try: deltat = ds.quan(ds.parameters["dDeltaStarForm"]*3.15569*10**7,'s')
+        except: deltat = ds.quan(10**6*3.15569*10**7,'s') # 1 Myr
+        # Star formation efficiency
+        try: cstarfac = ds.parameters["dCStar"]
+        except: cstarfac = 0.15
+        # Mass at which stars form (Msol)
+        try: massform = ds.quan(ds.parameters["dInitStarMass"]*ds.parameters["dMsolUnit"],'Msun')
+        except: massform = max(data[("newstars", "Mass")])
+        SFposs = np.where((data[("Gas","Temperature")]<tempcut) & (data[("Gas","Density")]>denscut))
+        try: cstar = cstarfac*data[("Gas","H2")][SFposs] # SF efficiency with molecular hydrogen
+        except: cstar = cstarfac*ds.data.arr(np.ones(len(data[("Gas","Mass")][SFposs])),"dimensionless")
+        dynt = 1.0/np.sqrt(data[("Gas","Density")][SFposs]*4.0*np.pi*G)
+        SFeff = 1.0 - np.e**(-1.0*cstar*deltat/dynt)
+        instsfr[SFposs] = (data[("Gas","Mass")][SFposs]/massform)*SFeff
+        return instsfr
 
     if fname != None:
-        ds = yt.load(fname,over_refine_factor=cfg.par.oref,n_ref=cfg.par.n_ref)
+        ds = yt.load(fname)
         ds.index
+    
+    #if we're in the 4.x branch of yt, load up the octree for smoothing
+    if float(yt.__version__[0:3]) >= 4:
+        left = np.array([pos[0] for pos in bounding_box])
+        right = np.array([pos[1] for pos in bounding_box])
+        # Add option for scatter vs gather to parameters_master file?
+        octree = ds.octree(left,right,n_ref=cfg.par.n_ref)
+        ds.parameters['octree'] = octree
     
 
     #set up particle filters to figure out which stars might have been
@@ -152,56 +181,61 @@ def tipsy_field_add(fname,bounding_box = None ,ds=None,add_smoothed_quantities=T
     ad = ds.all_data()
 
     #add the regular powderday fields
-    ds.add_field(('starmetals'),function=_starmetals,units="code_metallicity",particle_type=True)
-    ds.add_field(('starcoordinates'),function=_starcoordinates,units='cm',particle_type=True)
-    ds.add_field(('starformationtime'),function=_starformationtime,units='Gyr',particle_type=True)
-    ds.add_field(('stellarages'),function=_stellarages,units='Gyr',particle_type=True)
-    ds.add_field(('starmasses'),function=_starmasses,units='g',particle_type=True)
-    ds.add_field(('gasdensity'),function=_gasdensity,units='g/cm**3',particle_type=True)
-    ds.add_field(('gasmetals'),function=_gasmetals,units="code_metallicity",particle_type=True)
-    ds.add_field(('gascoordinates'),function=_gascoordinates,units='cm',particle_type=True)
+    ds.add_field(("star","metals"),function=_starmetals,units="code_metallicity",sampling_type='particle')
+    ds.add_field(("star","coordinates"),function=_starcoordinates,units='cm',sampling_type='particle')
+    ds.add_field(("star","formationtime"),function=_starformationtime,units='Gyr',sampling_type='particle')
+    ds.add_field(("stellar","ages"),function=_stellarages,units='Gyr',sampling_type='particle')
+    ds.add_field(("star","masses"),function=_starmasses,units='g',sampling_type='particle')
+    ds.add_field(("gas","density"),function=_gasdensity,units='g/cm**3',sampling_type='particle')
+    ds.add_field(("gas","metals"),function=_gasmetals,units="code_metallicity",sampling_type='particle')
+    ds.add_field(("gas","coordinates"),function=_gascoordinates,units='cm',sampling_type='particle')
     if add_smoothed_quantities == True:
-        ds.add_field(('gassmootheddensity'),function=_gassmootheddensity,units='g/cm**3',particle_type=True)
-        ds.add_field(('gassmoothedmetals'),function=_gassmoothedmetals,units='code_metallicity',particle_type=True)
-        ds.add_field(('gassmoothedmasses'),function=_gassmoothedmasses,units='g',particle_type=True)
-    ds.add_field(('gasmasses'),function=_gasmasses,units='g',particle_type=True)
-    ds.add_field(('gasfh2'),function=_gasfh2,units='dimensionless',particle_type=True)
-    ds.add_field(('gassfr'),function=_gassfr,units='g/s',particle_type=True)
-    ds.add_field(('metaldens'),function=_metaldens,units="g/cm**3", particle_type=True)
+        ds.add_field(("gas","smootheddensity"),function=_gassmootheddensity,units='g/cm**3',sampling_type='particle')
+        ds.add_field(("gas","smoothedmetals"),function=_gassmoothedmetals,units='code_metallicity',sampling_type='particle')
+        ds.add_field(("gas","smoothedmasses"),function=_gassmoothedmasses,units='g',sampling_type='particle')
+    ds.add_field(("gas","masses"),function=_gasmasses,units='g',sampling_type='particle')
+    ds.add_field(("gas","fh2"),function=_gasfh2,units='dimensionless',sampling_type='particle')
+    ds.add_field(("gas","sfr"),function=_gassfr,units='g/s',sampling_type='particle')
+    ds.add_field(("gas","smoothinglength"),function=_gassmoothinglength,units='pc',sampling_type='particle')
+    ds.add_field(("metal","dens"),function=_metaldens,units="g/cm**3", sampling_type='particle')
     #only add the disk star fields if there are any disk stars
     if len(ad["diskstars","Mass"]) > 0 :
-        ds.add_field(('diskstarmasses'),function=_diskstarmasses,units='g',particle_type=True)
-        ds.add_field(('diskstarcoordinates'),function=_diskstarcoordinates,units='cm',particle_type=True)
+        ds.add_field(("diskstar","masses"),function=_diskstarmasses,units='g',sampling_type='particle')
+        ds.add_field(("diskstar","coordinates"),function=_diskstarcoordinates,units='cm',sampling_type='particle')
 
     #add the dust mass, but only if we're using the DTM dust mass
     if cfg.par.dust_grid_type == 'dtm':
-        ds.add_field(('dustmass'), function=_dustmass_dtm,units='code_mass',particle_type=True)
+        ds.add_field(("dust","mass"), function=_dustmass_dtm,units='code_mass',sampling_type='particle')
 
     if cfg.par.dust_grid_type == 'rr':
-        ds.add_field(("dustmass"),function=_dustmass_rr,  units='code_mass',particle_type=True)
+        ds.add_field(("dust","mass"),function=_dustmass_rr,  units='code_mass',sampling_type='particle')
 
 
 
     if cfg.par.dust_grid_type == 'li_ml':
-        raise KeyError("Right now li_ml does not work for tipsy front ends.  Please set another dust grid type in the parameters")
+        if float(yt.__version__[0:3]) < 4:
+            raise KeyError("li_ml is not implemented for tipsy front ends with yt<4. Please set another dust grid type in the parameters or upgrade to yt4")
         #the issue is that we can't smooth the dust onto a grid that
         #is necessary in dust_grid_gen/li_ml_oct because yt3.x
         #requires a field: ('PartType0', 'particle_position').
-
-
-        #try: np.sum(ad["gasssfr"]) > 0:
-        #    ds.add_field(("dustmass"),function=_dustmass_li_ml, units='code_mass',particle_type=True)
-        #    ds.add_field(('PartType0','li_ml_dustmass'),function=_dustmass_li_ml,units='code_mass',particle_type=True)
-        #    ds.add_deposited_particle_field(("PartType0","li_ml_dustmass"),"sum")
-        #    if add_smoothed_quantities == True:
-        #        ds.add_field(("li_ml_dustsmoothedmasses"), function=_li_ml_dustsmoothedmasses, units='code_mass',particle_type=True)
-        #except: 
-        #     raise KeyError('The Gas SFR sums to zero; hence the li_ml model will not work.  Please set another dust grid type in the parameters.')
+        else:
+        #get the dust to gas ratio
+            ad = ds.all_data()
+            li_ml_dgr = dgr_ert(ad["Gas","Metals"],ad["gas","sfr"],ad["Gas","Mass"])
+            li_ml_dustmass = ((10.**li_ml_dgr)*ad["Gas","Mass"]).in_units('code_mass')
+            #this is an icky way to pass this to the function for ds.add_field in the next line. but such is life.
+            ds.parameters['li_ml_dustmass'] = li_ml_dustmass
+            ds.add_field(("Gas","li_ml_dustmass"),function=_li_ml_dustmass,units='code_mass',sampling_type='particle')
+            #just adding a new field that is called 'dustmass' so that we
+            #can save it later in analytics.
+            ds.add_field(("dust","mass"),function=_li_ml_dustmass,units='code_mass',sampling_type='particle')
+            ds.add_deposited_particle_field(("Gas","li_ml_dustmass"),"sum")
+            if add_smoothed_quantities == True:
+                ds.add_field(("Gas","li_ml_dustsmoothedmasses"), function=_li_ml_dustsmoothedmasses,units='code_mass',sampling_type='particle')
 
 
     if cfg.par.dust_grid_type == 'li_bestfit':
-        ds.add_field(("dustmass"),function=_dustmass_li_bestfit,  units='code_mass',particle_type=True)
+        ds.add_field(("dust","mass"),function=_dustmass_li_bestfit,  units='code_mass',sampling_type='particle')
 
     ad = ds.all_data()
     return ds
-


### PR DESCRIPTION
Changes to tipsy2pd.py allow tipsy output files to be used with yt.4. I've also changed _gassfr to calculate the instantaneous gas SFR for tipsy outputs, since Gasoline doesn't usually calculate this in-situ, and adapted the various gadget2pd li_ml functions to work with tipsy fields. There's also a small re-ordering of pd_front_end.py so that the 'solar' variable is defined earlier, since this is called by the frontends when users select the 'rr' dust grid type.