### PR TITLE
Minor Updates and Bug fixes

### DIFF
--- a/pd_front_end.py
+++ b/pd_front_end.py
@@ -231,6 +231,9 @@ print('Setting up Model')
 m_imaging = copy.deepcopy(m)
 m.conf.output.output_specific_energy = 'last'
 
+if ds_type in ['gadget_hdf5','tipsy','arepo_hdf5']:
+    dump_data(reg, model)
+
 if cfg.par.add_neb_emission and cfg.par.add_DIG_neb:
     make_DIG_SED(m, par, model)
     DIG_source_add(m, reg, df_nu,boost)
@@ -239,9 +242,6 @@ if cfg.par.add_neb_emission and cfg.par.add_DIG_neb:
 
 if cfg.par.SED:
     make_SED(m, par, model)
-
-if ds_type in ['gadget_hdf5','tipsy','arepo_hdf5']:
-    dump_data(reg, model)
 
 if cfg.par.IMAGING:
     make_image(m_imaging, par, model, dx, dy, dz)

--- a/powderday/front_end_tools.py
+++ b/powderday/front_end_tools.py
@@ -34,6 +34,7 @@ def make_SED(m, par, model):
 
         m.set_n_initial_iterations(3)
         m.set_convergence(True, percentile=99., absolute=1.01, relative=1.01)
+        m.set_copy_input(False)
         sed = m.add_peeled_images(sed=True, image=False)
 
         if cfg.par.MANUAL_ORIENTATION == True:

--- a/powderday/front_ends/gadget2pd.py
+++ b/powderday/front_ends/gadget2pd.py
@@ -305,7 +305,7 @@ def gadget_field_add(fname, bounding_box=None, ds=None,add_smoothed_quantities=T
     # load the ds (but only if this is our first passthrough and we pass in fname)
     if fname != None:
         if float(yt.__version__[0:3]) >= 4:
-            ds = yt.load(fname)
+            ds = yt.load(fname, bounding_box=bounding_box)
             
             #ds.sph_smoothing_style = "gather"
             ds.index

--- a/powderday/source_creation.py
+++ b/powderday/source_creation.py
@@ -624,9 +624,8 @@ def DIG_source_add(m,reg,df_nu,boost):
 
     fnu_arr_neb = sg.get_dig_seds(lam_arr, fnu_arr, logU, cell_width, met)
     
-    nu = 1.e8 * constants.c.cgs.value / lam
-
     for i in range(len(logU)):
+        nu = 1.e8 * constants.c.cgs.value / lam
         fnu = fnu_arr_neb[i,:]
         nu, fnu = wavelength_compress(nu,fnu,df_nu)
         
@@ -637,5 +636,5 @@ def DIG_source_add(m,reg,df_nu,boost):
         
         source = m.add_point_source()
         source.luminosity = lum # [ergs/s]
-        source.spectrum = (nu[::-1],fnu[::-1])
+        source.spectrum = (nu,fnu)
         source.position = pos[i] # [cm]

--- a/tests/SKIRT/gizmo_mw_zoom/pd_test.dust.ski
+++ b/tests/SKIRT/gizmo_mw_zoom/pd_test.dust.ski
@@ -33,7 +33,7 @@
                     </SPHDustDistribution>
                 </dustDistribution>
                 <dustGrid type="DustGrid">
-                    <OctTreeDustGrid writeGrid="true" minX="40183000 pc" maxX="40383000 pc" minY="31824000 pc" maxY="32024000 pc" minZ="40834635 pc" maxZ="41034635.70342197 pc" minLevel="3" maxLevel="14" searchMethod="Neighbor" numSamples="100" maxOpticalDepth="0" maxMassFraction="2e-5" maxDensityDispersion="0" writeTree="false" useBarycentric="false"/>
+                    <OctTreeDustGrid writeGrid="true" minX="40183000 pc" maxX="40384000 pc" minY="31824000 pc" maxY="32025000 pc" minZ="40834635 pc" maxZ="41034636 pc" minLevel="3" maxLevel="14" searchMethod="Neighbor" numSamples="100" maxOpticalDepth="0" maxMassFraction="2e-5" maxDensityDispersion="0" writeTree="false" useBarycentric="false"/>
                 </dustGrid>
                 <dustEmissivity type="DustEmissivity">
                     <GreyBodyDustEmissivity/>


### PR DESCRIPTION
Minor changes
1. copy input is set to False by default for Hyperion. The rtout files will now not contain any info about the input sources which should lead to a reduction in file size.

Bug fixes:
1. Grid info is now dumped before DIG neb emission calculation. 
2. Wavelength array in DIG calculation was being flipped after every iteration. This is now fixed.
3. Expanded SKIRT grid size in SKIRT tests (gizmo_mw_zoom) to match the powderday box limit. This fixes issue #179 
4. The bounding box is now passed when loading the file in yt4. Not doing so was causing some runs to crash.