### PR TITLE
fix scikit-learn install in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'yt',
         'unyt',
         'fsps',
-        'sklearn',
+        'scikit-learn',
         'p_tqdm'
     ],
     scripts=["pd_front_end.py"],


### PR DESCRIPTION
fixes the install name for scikit-learn in `setup.py`, see [here](https://scikit-learn.org/stable/install.html).

fixes the following error when using `python setup.py install`:

        Searching for sklearn
        Reading https://pypi.org/simple/sklearn/
        /cosma7/data/dp004/dc-love2/codes/simba_dusty_quiescent/pd_env/lib/python3.10/site-packages/pkg_resources/__init__.py:123: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
          warnings.warn(
        Downloading https://files.pythonhosted.org/packages/b9/0e/b2a4cfaa9e12b9ca4c71507bc26d2c99d75de172c0088c9835a98cf146ff/sklearn-0.0.post10.tar.gz#sha256=d4cd5a2e64b3caaf82cd5e33c46884dfeec5ebf991710d9faeb4fe81cadb3ba6
        Best match: sklearn 0.0.post10
        Processing sklearn-0.0.post10.tar.gz
        Writing /tmp/easy_install-uxvz1fgk/sklearn-0.0.post10/setup.cfg
        Running sklearn-0.0.post10/setup.py -q bdist_egg --dist-dir /tmp/easy_install-uxvz1fgk/sklearn-0.0.post10/egg-dist-tmp-6jm7uacf
        error: Setup script exited with The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
        rather than 'sklearn' for pip commands. 
        
        Here is how to fix this error in the main use cases:
        - use 'pip install scikit-learn' rather than 'pip install sklearn'
        - replace 'sklearn' by 'scikit-learn' in your pip requirements files
          (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
        - if the 'sklearn' package is used by one of your dependencies,
          it would be great if you take some time to track which package uses
          'sklearn' instead of 'scikit-learn' and report it to their issue tracker
        - as a last resort, set the environment variable
          SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
