### PR TITLE
fixing bug when running powderday in job array

### DIFF
--- a/powderday/active_dust/dust_file_writer.py
+++ b/powderday/active_dust/dust_file_writer.py
@@ -243,9 +243,9 @@ def dust_file_writer(nsizes):
 
         d = IsotropicDust(nu.value,albedo,kappa_lambda)
 
-        if not os.path.exists(cfg.par.pd_source_dir+'/powderday/active_dust/dust_files/'):
-            os.makedirs(cfg.par.pd_source_dir+'/powderday/active_dust/dust_files/')
-        filename = cfg.par.pd_source_dir+'/powderday/active_dust/dust_files/binned_dust_sizes.'+str(counter)+'.hdf5'
+        if not os.path.exists(cfg.model.PD_output_dir+'/dust_files/'):
+            os.makedirs(cfg.model.PD_output_dir+'/dust_files/')
+        filename = cfg.model.PD_output_dir+'/dust_files/binned_dust_sizes.'+str(counter)+'.hdf5'
         outfile_filenames.append(filename)
 
         d.write(filename)
@@ -262,7 +262,7 @@ def dust_file_writer(nsizes):
     z = np.asarray(outfile_filenames)
     #np.savetxt('dust_files/binned_dust_sizes.key',np.transpose([grain_size_left_edge_array[0:-1],grain_size_right_edge_array,np.asarray(outfile_filenames)]))
 
-    np.savez(cfg.par.pd_source_dir+'/powderday/active_dust/dust_files/binned_dust_sizes.npz',grain_size_left_edge_array = grain_size_left_edge_array,grain_size_right_edge_array = grain_size_right_edge_array,outfile_filenames = outfile_filenames)
+    np.savez(cfg.model.PD_output_dir+'/dust_files/binned_dust_sizes.npz',grain_size_left_edge_array = grain_size_left_edge_array,grain_size_right_edge_array = grain_size_right_edge_array,outfile_filenames = outfile_filenames)
 
 
 

--- a/powderday/tributary_dust_add.py
+++ b/powderday/tributary_dust_add.py
@@ -36,7 +36,7 @@ def active_dust_add(ds,m,grid_of_sizes,nsizes,dustdens,specific_energy,refined=[
 
 
         #now load the mapping between grain bin and filename for the lookup table
-        data = np.load(cfg.par.pd_source_dir+'/powderday/active_dust/dust_files/binned_dust_sizes.npz')
+        data = np.load(cfg.model.PD_output_dir+'/dust_files/binned_dust_sizes.npz')
         grain_size_left_edge_array = data['grain_size_left_edge_array']
         grain_size_right_edge_array  = data['grain_size_right_edge_array']
         dust_filenames = data['outfile_filenames']


### PR DESCRIPTION
Since active dust files were being written to a powderday directory, and these files can only be opened in one instance at a time, they caused a crash when trying to do multiple runs in parallel. Here, we write dust files to the output directory to avoid this problem.